### PR TITLE
Refactor breadcrumbs to use link builder and snippets

### DIFF
--- a/src/breadcrumbs/breadcrumb.spec.jsx
+++ b/src/breadcrumbs/breadcrumb.spec.jsx
@@ -1,46 +1,37 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Breadcrumb } from './';
+import Snippet from '../snippet';
+import Link from '../link';
 
 describe('<Breadcrumb />', () => {
-  describe('with a string', () => {
-    const crumb = 'A crumb';
-    const wrapper = shallow(<Breadcrumb crumb={crumb} />);
-    const el = wrapper.find('li');
 
-    test('renders one li', () => {
-      expect(el.length).toBe(1);
-    });
-
-    test('renders the crumb text', () => {
-      expect(el.text()).toBe(crumb);
-    });
-
-    test('doesn\'t render a link', () => {
-      expect(el.find('a').length).toBe(0);
-    });
+  test('renders one li', () => {
+    const wrapper = shallow(<Breadcrumb crumb="dashboard" link={true} />);
+    expect(wrapper.find('li').length).toBe(1);
   });
 
-  describe('with an object', () => {
-    const crumb = { href: '/a-link', label: 'A link' };
-    const wrapper = shallow(<Breadcrumb crumb={crumb} />);
-    const el = wrapper.find('li');
-
-    test('renders one li', () => {
-      expect(el.length).toBe(1);
-    });
-
-    test('renders the crumb label', () => {
-      expect(el.text()).toBe(crumb.label);
-    });
-
-    test('renders a link', () => {
-      expect(el.find('a').length).toBe(1);
-    });
-
-    test('passes the href and label as props', () => {
-      expect(el.find('a').props()).toHaveProperty('children', 'A link');
-      expect(el.find('a').props()).toHaveProperty('href', '/a-link');
-    });
+  test('renders a Link component if `link` prop is true', () => {
+    const wrapper = shallow(<Breadcrumb crumb="dashboard" link={true} />);
+    expect(wrapper.find(Link).length).toBe(1);
+    expect(wrapper.find(Link).last().props().page).toBe('dashboard');
   });
+
+  test('passes a Snippet as the link label', () => {
+    const wrapper = shallow(<Breadcrumb crumb="dashboard" link={true} />);
+    expect(wrapper.find(Link).length).toBe(1);
+    expect(wrapper.find(Link).at(0).props().label).toEqual(<Snippet>breadcrumbs.dashboard</Snippet>);
+  });
+
+  test('does not render a Link component if `link` prop is false', () => {
+    const wrapper = shallow(<Breadcrumb crumb="dashboard" link={false} />);
+    expect(wrapper.find(Link).length).toBe(0);
+  });
+
+  test('renders a Snippet', () => {
+    const wrapper = shallow(<Breadcrumb crumb="dashboard" link={false} />);
+    expect(wrapper.find(Snippet).length).toBe(1);
+    expect(wrapper.find(Snippet).props().children).toEqual('breadcrumbs.dashboard');
+  });
+
 });

--- a/src/breadcrumbs/breadcrumbs.spec.jsx
+++ b/src/breadcrumbs/breadcrumbs.spec.jsx
@@ -19,54 +19,46 @@ describe('<Breadcrumbs />', () => {
   });
 
   describe('with one crumb', () => {
-    const crumbs = ['A crumb'];
+    const crumbs = ['dashboard'];
     const wrapper = shallow(<Breadcrumbs crumbs={crumbs} />);
 
-    test('renders 2 <Breadcrumb /> elements', () => {
-      expect(wrapper.find(Breadcrumb).length).toBe(2);
+    test('renders 1 <Breadcrumb /> elements', () => {
+      expect(wrapper.find(Breadcrumb).length).toBe(1);
     });
 
-    test('passes a home link crumb to the first <Breadcrumb />', () => {
-      const el = wrapper.find(Breadcrumb).first();
-      expect(el.props().crumb).toEqual({ href: '/', label: 'Home' });
-    });
-
-    test('passes a label crumb to the last <Breadcrumb />', () => {
+    test('passes a label crumb to the <Breadcrumb />', () => {
       const el = wrapper.find(Breadcrumb).last();
-      expect(el.props().crumb).toBe('A crumb');
+      expect(el.props().crumb).toEqual('dashboard');
+      expect(el.props().link).toEqual(false);
     });
   });
 
   describe('with many crumbs', () => {
     const crumbs = [
-      { href: '/page-1', label: 'Page 1' },
-      { href: '/page-1/child-page', label: 'Child Page' },
-      'A crumb'
+      'dashboard',
+      'establishment.dashboard',
+      'projects'
     ];
     const wrapper = shallow(<Breadcrumbs crumbs={crumbs} />);
 
-    test('renders 4 <Breadcrumb /> elements', () => {
-      expect(wrapper.find(Breadcrumb).length).toBe(4);
+    test('renders 3 <Breadcrumb /> elements', () => {
+      expect(wrapper.find(Breadcrumb).length).toBe(3);
     });
 
-    test('passes a home link crumb to the first <Breadcrumb />', () => {
-      const el = wrapper.find(Breadcrumb).first();
-      expect(el.props().crumb).toEqual({ href: '/', label: 'Home' });
+    test('passes links to the first 2 <Breadcrumb /> elements', () => {
+      const el0 = wrapper.find(Breadcrumb).at(0);
+      expect(el0.props().crumb).toEqual('dashboard');
+      expect(el0.props().link).toEqual(true);
+      const el1 = wrapper.find(Breadcrumb).at(1);
+      expect(el1.props().crumb).toEqual('establishment.dashboard');
+      expect(el1.props().link).toEqual(true);
     });
 
-    test('passes a label crumb to the last <Breadcrumb />', () => {
+    test('does not link the last <Breadcrumb />', () => {
       const el = wrapper.find(Breadcrumb).last();
-      expect(el.props().crumb).toBe('A crumb');
+      expect(el.props().crumb).toEqual('projects');
+      expect(el.props().link).toEqual(false);
     });
 
-    test('passes an intermediate link crumb to the second <Breadcrumb />', () => {
-      const el = wrapper.find(Breadcrumb).at(1);
-      expect(el.props().crumb).toEqual(crumbs[0]);
-    });
-
-    test('passes an intermediate link crumb to the third <Breadcrumb />', () => {
-      const el = wrapper.find(Breadcrumb).at(2);
-      expect(el.props().crumb).toBe(crumbs[1]);
-    });
   });
 });

--- a/src/breadcrumbs/index.jsx
+++ b/src/breadcrumbs/index.jsx
@@ -1,29 +1,34 @@
 import React from 'react';
+import Link from '../link';
+import Snippet from '../snippet';
 
 export const Breadcrumb = ({
-  crumb
-}) => typeof crumb === 'string'
-  ? <li className="govuk-breadcrumbs__list-item">{crumb}</li>
-  : <li className="govuk-breadcrumbs__list-item">
-    <a href={crumb.href} className="govuk-breadcrumbs__link">{crumb.label}</a>
+  crumb = {},
+  link = false
+}) => {
+  return <li className="govuk-breadcrumbs__list-item">
+  {
+    link ?
+      <Link page={crumb} label={<Snippet>{`breadcrumbs.${crumb}`}</Snippet>} /> :
+      <Snippet>{`breadcrumbs.${crumb}`}</Snippet>
+  }
   </li>;
+};
 
 const renderNull = crumbs => !crumbs || !crumbs.length || !Array.isArray(crumbs);
 
 const Breadcrumbs = ({
-  crumbs,
-  homeLabel = 'Home'
+  crumbs
 }) => {
   if (renderNull(crumbs)) {
     return null;
   }
-  crumbs = [ { label: homeLabel, href: '/' }, ...crumbs ];
   return (
     <div className="govuk-breadcrumbs">
       <ol className="govuk-breadcrumbs__list">
         {
           crumbs.map((crumb, index) =>
-            <Breadcrumb key={index} crumb={crumb} />
+            <Breadcrumb key={index} crumb={crumb} link={index !== crumbs.length - 1} />
           )
         }
       </ol>

--- a/src/snippet/index.jsx
+++ b/src/snippet/index.jsx
@@ -30,6 +30,6 @@ export const Snippet = ({ content, children, optional, ...props }) => {
   );
 };
 
-const mapStateToProps = ({ static: { content } }) => ({ content });
+const mapStateToProps = ({ static: { content, establishment }, model }) => ({ content, establishment, model });
 
 export default connect(mapStateToProps)(Snippet);


### PR DESCRIPTION
* Use url builder with page properties to build breadcrumbs
* Load breadcrumb content from `<Snippet />` components
* Automatically link all breadcrumbs except the last
* Expose more properties to the mustache render in `<Snippet />`