### PR TITLE
Allow datatables to have conditional expanding rows

### DIFF
--- a/src/datatable/index.jsx
+++ b/src/datatable/index.jsx
@@ -13,11 +13,11 @@ export class Datatable extends Component {
   constructor(options) {
     super(options);
     this.toggleContent = this.toggleContent.bind(this);
-    this.isExpandable = this.isExpandable.bind(this);
+    this.isExpanded = this.isExpanded.bind(this);
   }
 
   componentDidMount() {
-    if (!this.props.ExpandableRow) {
+    if (!this.props.expands) {
       return;
     }
     const expanded = this.props.data.reduce((obj, { id }) => {
@@ -32,8 +32,8 @@ export class Datatable extends Component {
     this.setState({ expanded });
   }
 
-  isExpandable(id) {
-    if (this.props.ExpandableRow) {
+  isExpanded(id) {
+    if (this.props.expands) {
       if (!this.state) {
         return true;
       }
@@ -47,7 +47,7 @@ export class Datatable extends Component {
       schema,
       sortable,
       isFetching,
-      ExpandableRow,
+      expands,
       className
     } = this.props;
 
@@ -65,14 +65,14 @@ export class Datatable extends Component {
         </thead>
         <tbody>
           {
-            data.map(row => (
-              <Fragment key={row.id}>
+            data.map(row => {
+              const expansion = expands && expands(row);
+              const expandable = !!expansion;
+              const expanded = this.isExpanded(row.id);
+              return <Fragment key={row.id}>
                 <tr
-                  onClick={ExpandableRow && (() => this.toggleContent(row.id))}
-                  className={classnames({
-                    expandable: ExpandableRow,
-                    expanded: ExpandableRow && this.state && this.state.expanded[row.id]
-                  })}
+                  onClick={expansion && (() => this.toggleContent(row.id))}
+                  className={classnames({ expandable, expanded })}
                 >
                   {
                     map(schema, (column, key) => {
@@ -84,22 +84,17 @@ export class Datatable extends Component {
                   }
                 </tr>
                 {
-                  this.isExpandable(row.id) && (
+                  expanded && (
                     <tr className='expanded-content' onClick={() => this.toggleContent(row.id)}>
                       <td colSpan={size(schema)}>
-                        {
-                          <ExpandableRow
-                            row={row}
-                            schema={schema}
-                          />
-                        }
+                        { expansion }
                       </td>
                     </tr>
                   )
                 }
               </Fragment>
 
-            ))
+            })
           }
         </tbody>
         <tfoot>

--- a/src/datatable/index.spec.jsx
+++ b/src/datatable/index.spec.jsx
@@ -102,25 +102,41 @@ describe('<Datatable />', () => {
     let schema;
     let data;
 
+    const expands = row => {
+      return row.number % 2 ? null : <div className="expanding">{ row.number }</div>;
+    }
+
     beforeEach(() => {
       data = [
-        { id: 1, site: 'A Site', name: 'The Name', number: 3 }
+        { id: 1, site: 'A Site', name: 'The Name', number: 3 },
+        { id: 2, site: 'A Site', name: 'The Name', number: 4 },
+        { id: 3, site: 'A Site', name: 'The Name', number: 5 },
+        { id: 4, site: 'A Site', name: 'The Name', number: 6 }
       ];
       schema = {
         site: { show: true },
         name: { show: true },
         number: { show: true }
       };
-      wrapper = shallow(<Datatable data={data} schema={schema} ExpandableRow={() => {}} />);
+      wrapper = shallow(<Datatable data={data} schema={schema} expands={expands} />);
     });
 
     test('renders expandable rows if expandable prop is true', () => {
-      expect(wrapper.find('tr.expandable').length).toBe(1);
+      expect(wrapper.find('tr.expandable').length).toBe(2);
     });
 
-    test('sets state to expanded for the row if clicked', () => {
-      wrapper.find('tr.expandable').simulate('click');
-      expect(wrapper.instance().state.expanded).toEqual({ '1': true });
+    test('shows expanding content for a row when clicked', () => {
+      wrapper.find('tr.expandable').first().simulate('click');
+      const expanded = wrapper.find('div.expanding');
+      expect(expanded.length).toEqual(1);
+      expect(expanded.text()).toEqual('4');
+    });
+
+    test('clicking an open row closes it', () => {
+      wrapper.find('tr.expandable').first().simulate('click');
+      expect(wrapper.find('div.expanding').length).toEqual(1);
+      wrapper.find('tr.expandable').first().simulate('click');
+      expect(wrapper.find('div.expanding').length).toEqual(0);
     });
 
   });

--- a/src/filter-table/index.jsx
+++ b/src/filter-table/index.jsx
@@ -3,7 +3,7 @@ import { Datatable, Filters, FilterSummary, Link, Snippet } from '../';
 
 const FilterTable = ({
   formatters,
-  ExpandableRow,
+  expands,
   createPath
 }) => (
   <Fragment>
@@ -14,7 +14,7 @@ const FilterTable = ({
         createPath && <Link label={<Snippet>addNew</Snippet>} page={createPath} />
       }
     </div>
-    <Datatable formatters={ formatters } ExpandableRow={ExpandableRow} />
+    <Datatable formatters={ formatters } expands={expands} />
   </Fragment>
 );
 


### PR DESCRIPTION
Depending on a user's permissions and the data to be shown in a row, not all rows of the schedule of premises will have anything to display if they expand.

Make the expandable property of a datatable component conditional per-row to enable this.