### PR TITLE
Keep button margins when in context of control sets

### DIFF
--- a/src/control-bar/index.scss
+++ b/src/control-bar/index.scss
@@ -1,9 +1,4 @@
 .control-bar {
-
-  .govuk-button {
-    margin-bottom: 0;
-  }
-
   &.block {
     > * {
       display: block;


### PR DESCRIPTION
This causes some weirdness when using a control bar to align a set of controls and the margin disappears when compared with unwrapped standalone buttons.

If there's a particular context where the lack of margin is desirable then I will find those and remove the margin only for that context, but the default should preserve margins.