### PR TITLE
Move margins on control-bar components

### DIFF
--- a/src/control-bar/index.scss
+++ b/src/control-bar/index.scss
@@ -1,4 +1,11 @@
 .control-bar {
+
+  margin-bottom: $govuk-gutter;
+
+  .govuk-button {
+    margin-bottom: 0;
+  }
+
   &.block {
     > * {
       display: block;


### PR DESCRIPTION
The buttons need to have a zero margin to ensure they can be correctly vertically aligned with text links. Instead move the margin onto the wrapper element to ensure correct page flow.