### PR TITLE
don't filter visible==false cause it breaks remove button

### DIFF
--- a/src/add-another/index.jsx
+++ b/src/add-another/index.jsx
@@ -38,7 +38,7 @@ class AddAnother extends Component {
 
     return (
       <div className="add-another">
-        { visible.filter(Boolean).map((isVisible, index) => {
+        { visible.map((isVisible, index) => {
           const id = children.props.id ? `${children.props.id}-${index}` : undefined;
           return isVisible &&
             <div key={index} className="govuk-grid-row add-another-item">


### PR DESCRIPTION
The species select remove button only worked properly if you removed the last visible selector, rather than any visible selector.

Should now work for any selector.