### PR TITLE
restrict panel styling to direct child of panel-list

### DIFF
--- a/src/panel-list/index.scss
+++ b/src/panel-list/index.scss
@@ -2,7 +2,7 @@
   list-style: none;
   padding-left: 0;
 
-  li {
+  &>li {
     background: $highlight-colour;
     @extend .govuk-heading-m;
     border: 1px solid govuk-colour('grey-1');


### PR DESCRIPTION
If we have `li`s inside a panel then don't style them as nested panels.