### PR TITLE
Fix expired notice for recent expiry dates

### DIFF
--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { Snippet } from '../';
+import isPast from 'date-fns/is_past';
 import differenceInMonths from 'date-fns/difference_in_months';
 import differenceInWeeks from 'date-fns/difference_in_weeks';
 import differenceInDays from 'date-fns/difference_in_days';
@@ -31,11 +32,10 @@ const ExpiryDate = ({
 
   let contentKey = 'diff.standard';
 
-  if (urgent) {
-    contentKey = diff === 0 ? 'diff.singular' : 'diff.plural';
-  }
-  if (diff < 0) {
+  if (isPast(date)) {
     contentKey = 'diff.expired';
+  } else if (urgent) {
+    contentKey = diff === 0 ? 'diff.singular' : 'diff.plural';
   }
 
   return (


### PR DESCRIPTION
If an expiry date is in the recent past then the difference in months will still return zero, and it will be shown as soon to expire.

Replace the check of months difference `< 0` with a call to `isPast` to ensure all expiry dates in the past show correctly as expired.