### PR TITLE
Don't render anything in expiry date component if no date prop

### DIFF
--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -15,6 +15,11 @@ const ExpiryDate = ({
   showUrgent = 3,
   showNotice = 11
 }) => {
+
+  if (!date) {
+    return null;
+  }
+
   let differenceFunction;
   switch (unit) {
     case 'month':


### PR DESCRIPTION
This prevents any accidental 1st Jan 1970 action.