### PR TITLE
Normalise arguments from date component onChange

### DIFF
--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -20,7 +20,7 @@ const fields = {
       <h3>{ props.label }</h3>
       <ReactMarkdown>{ props.value }</ReactMarkdown>
     </div>,
-  dateInput: props => <DateInput { ...props } />
+  dateInput: props => <DateInput { ...props } onChange={value => props.onChange({ target: { value } })} />
 };
 
 class Fieldset extends Component {


### PR DESCRIPTION
Most fields are expected to call onChange with a raw DOM event, but the date component calls `onChange` with the string value. Pass a custom `onChange` prop to date components to normalise this back to a `{ target: { value: 'YYYY-MM-DD' } }` form for consistency with other fields.