### PR TITLE
Support explicit value prop in search component

### DIFF
--- a/src/search/index.jsx
+++ b/src/search/index.jsx
@@ -45,8 +45,8 @@ Search.defaultProps = {
   name: 'filter'
 };
 
-const mapStateToProps = ({ datatable: { filters } }) => ({
-  filter: filters.active['*'] ? filters.active['*'][0] : ''
+const mapStateToProps = ({ datatable: { filters } }, { value }) => ({
+  filter: value || (filters.active['*'] ? filters.active['*'][0] : '')
 });
 
 export default connect(


### PR DESCRIPTION
Instead of always reading the value of the field from a datatable in redux, allow the explicit setting of a value prop for use in cases where no datatable is used.