### PR TITLE
Fix the ExpiryDate component

### DIFF
--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -1,52 +1,43 @@
 import React, { Fragment } from 'react';
 import { Snippet } from '../';
-import differenceInMonths from 'date-fns/difference_in_calendar_months';
-import differenceInWeeks from 'date-fns/difference_in_calendar_weeks';
+import differenceInMonths from 'date-fns/difference_in_months';
+import differenceInWeeks from 'date-fns/difference_in_weeks';
 import differenceInDays from 'date-fns/difference_in_calendar_days';
+import isBefore from 'date-fns/is_before';
 import format from 'date-fns/format';
 import classnames from 'classnames';
 
-const ExpiryDate = ({
-  date,
-  dateFormat,
-  unit = 'month',
-  adjustment = 0,
-  showUrgent = 3,
-  showNotice = 11
-}) => {
+const ExpiryDate = ({ date, dateFormat, unit, adjustment, showUrgent, showNotice }) => {
   if (!date) {
     return null;
   }
 
-  let differenceFunction;
-  switch (unit) {
-    case 'month':
-      differenceFunction = differenceInMonths;
-      break;
-    case 'week':
-      differenceFunction = differenceInWeeks;
-      break;
-    case 'day':
-      differenceFunction = differenceInDays;
-      break;
+  const now = new Date();
+
+  const diff = {
+    day: differenceInDays(date, now) + adjustment,
+    week: differenceInWeeks(date, now) + adjustment,
+    month: differenceInMonths(date, now) + adjustment
   }
-  const diff = differenceFunction(date, new Date()) + adjustment;
-  const urgent = diff < showUrgent;
+
+  const displayUnit = diff['month'] > 0 ? 'month' : (diff['week'] > 0 ? 'week' : 'day');
+  const displayDiff = diff['month'] > 0 ? diff['month'] : (diff['week'] > 0 ? diff['week'] : diff['day']);
+  const urgent = diff[unit] <= showUrgent;
 
   let contentKey = 'diff.standard';
 
-  if (diff <= 0) {
+  if (isBefore(date, new Date())) {
     contentKey = 'diff.expired';
   } else if (urgent) {
-    contentKey = diff === 1 ? 'diff.singular' : 'diff.plural';
+    contentKey = displayDiff === 1 ? 'diff.singular' : 'diff.plural';
   }
 
   return (
     <Fragment>
       {format(date, dateFormat)}
-      {diff <= showNotice && (
+      {diff[unit] <= showNotice && (
         <span className={classnames('notice', { urgent })}>
-          <Snippet diff={diff} unit={unit}>{contentKey}</Snippet>
+          <Snippet diff={displayDiff} unit={displayUnit}>{contentKey}</Snippet>
         </span>
       )}
     </Fragment>
@@ -54,7 +45,11 @@ const ExpiryDate = ({
 };
 
 ExpiryDate.defaultProps = {
-  dateFormat: 'DD MMMM YYYY'
+  dateFormat: 'DD MMMM YYYY',
+  unit: 'month',
+  adjustment: 0,
+  showUrgent: 3,
+  showNotice: 11
 };
 
 export default ExpiryDate;

--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -18,7 +18,7 @@ const ExpiryDate = ({ date, dateFormat, unit, adjustment, showUrgent, showNotice
     day: differenceInDays(date, now) + adjustment,
     week: differenceInWeeks(date, now) + adjustment,
     month: differenceInMonths(date, now) + adjustment
-  }
+  };
 
   const displayUnit = diff['month'] > 0 ? 'month' : (diff['week'] > 0 ? 'week' : 'day');
   const displayDiff = diff['month'] > 0 ? diff['month'] : (diff['week'] > 0 ? diff['week'] : diff['day']);

--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -1,8 +1,8 @@
 import React, { Fragment } from 'react';
 import { Snippet } from '../';
-import differenceInMonths from 'date-fns/difference_in_months';
-import differenceInWeeks from 'date-fns/difference_in_weeks';
-import differenceInDays from 'date-fns/difference_in_days';
+import differenceInMonths from 'date-fns/difference_in_calendar_months';
+import differenceInWeeks from 'date-fns/difference_in_calendar_weeks';
+import differenceInDays from 'date-fns/difference_in_calendar_days';
 import format from 'date-fns/format';
 import classnames from 'classnames';
 
@@ -38,7 +38,7 @@ const ExpiryDate = ({
   if (diff <= 0) {
     contentKey = 'diff.expired';
   } else if (urgent) {
-    contentKey = diff === 0 ? 'diff.singular' : 'diff.plural';
+    contentKey = diff === 1 ? 'diff.singular' : 'diff.plural';
   }
 
   return (
@@ -46,7 +46,7 @@ const ExpiryDate = ({
       {format(date, dateFormat)}
       {diff <= showNotice && (
         <span className={classnames('notice', { urgent })}>
-          <Snippet diff={diff}>{contentKey}</Snippet>
+          <Snippet diff={diff} unit={unit}>{contentKey}</Snippet>
         </span>
       )}
     </Fragment>

--- a/src/expiry-date/index.spec.jsx
+++ b/src/expiry-date/index.spec.jsx
@@ -34,7 +34,7 @@ describe('<ExpiryDate />', () => {
     const wrapper = shallow(<ExpiryDate date={addMonths(new Date(), 9)} />);
     expect(wrapper.find(Snippet).length).toBe(1);
     expect(wrapper.find(Snippet).props().unit).toEqual('month');
-    expect(wrapper.find(Snippet).props().diff).toEqual(9);
+    expect(wrapper.find(Snippet).props().children).toEqual('diff.standard');
   });
 
 });

--- a/src/expiry-date/index.spec.jsx
+++ b/src/expiry-date/index.spec.jsx
@@ -27,7 +27,7 @@ describe('<ExpiryDate />', () => {
     const wrapper = shallow(<ExpiryDate date={addWeeks(new Date(), 3)} />);
     expect(wrapper.find(Snippet).length).toBe(1);
     expect(wrapper.find(Snippet).props().unit).toEqual('week');
-    expect(wrapper.find(Snippet).props().diff).toEqual(3);
+    expect(wrapper.find(Snippet).props().children).toEqual('diff.plural');
   });
 
   test('shows less than x months left if the expiry date is greater than 1 month but less than a year', () => {

--- a/src/expiry-date/index.spec.jsx
+++ b/src/expiry-date/index.spec.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import ExpiryDate from './';
 import Snippet from '../snippet';
+import endOfTomorrow from 'date-fns/end_of_tomorrow';
+import addWeeks from 'date-fns/add_weeks';
+import addMonths from 'date-fns/add_months';
 
 describe('<ExpiryDate />', () => {
 
@@ -9,6 +12,29 @@ describe('<ExpiryDate />', () => {
     const wrapper = shallow(<ExpiryDate date={'2017-01-01'} />);
     expect(wrapper.find(Snippet).length).toBe(1);
     expect(wrapper.find(Snippet).props().children).toEqual('diff.expired');
+  });
+
+  test('shows urgent 1 day left message if the expiry date is tomorrow', () => {
+    const wrapper = shallow(<ExpiryDate date={endOfTomorrow()} />);
+    expect(wrapper.find(Snippet).length).toBe(1);
+    expect(wrapper.find(Snippet).props().children).toEqual('diff.singular');
+    expect(wrapper.find('span').props().className).toMatch('urgent');
+    expect(wrapper.find(Snippet).props().unit).toEqual('day');
+    expect(wrapper.find(Snippet).props().diff).toEqual(1);
+  });
+
+  test('shows less than x weeks left if the expiry date is greater than 1 week but less than a month', () => {
+    const wrapper = shallow(<ExpiryDate date={addWeeks(new Date(), 3)} />);
+    expect(wrapper.find(Snippet).length).toBe(1);
+    expect(wrapper.find(Snippet).props().unit).toEqual('week');
+    expect(wrapper.find(Snippet).props().diff).toEqual(3);
+  });
+
+  test('shows less than x months left if the expiry date is greater than 1 month but less than a year', () => {
+    const wrapper = shallow(<ExpiryDate date={addMonths(new Date(), 9)} />);
+    expect(wrapper.find(Snippet).length).toBe(1);
+    expect(wrapper.find(Snippet).props().unit).toEqual('month');
+    expect(wrapper.find(Snippet).props().diff).toEqual(9);
   });
 
 });


### PR DESCRIPTION
Fixed a couple of issues: 

The diff would always be `0` if the date was tomorrow, so we were showing the date as expired before it was.

We were showing the plural message for a diff of `1` (e.g. "less than 1 days left")

If the unit was "days" and the diff was `61` we were displaying "61 months left"