### PR TITLE
Breakout countdown into it's own component

### DIFF
--- a/src/countdown/index.jsx
+++ b/src/countdown/index.jsx
@@ -6,7 +6,7 @@ import differenceInDays from 'date-fns/difference_in_calendar_days';
 import isBefore from 'date-fns/is_before';
 import classnames from 'classnames';
 
-const Countdown = ({ expiry, unit, showUrgent }) => {
+const Countdown = ({ expiry, unit, showNotice, showUrgent }) => {
   const now = new Date();
 
   const diff = {
@@ -14,6 +14,10 @@ const Countdown = ({ expiry, unit, showUrgent }) => {
     week: differenceInWeeks(expiry, now),
     month: differenceInMonths(expiry, now)
   };
+
+  if (showNotice !== true && diff[unit] > showNotice) {
+    return null;
+  }
 
   const displayUnit = diff['day'] <= 7 ? 'day' : (diff['day'] <= 28 ? 'week' : 'month');
   const displayDiff = displayUnit === 'day' ? diff[displayUnit] : diff[displayUnit] + 1;
@@ -34,6 +38,7 @@ const Countdown = ({ expiry, unit, showUrgent }) => {
 
 Countdown.defaultProps = {
   unit: 'month',
+  showNotice: 11,
   showUrgent: 3
 };
 

--- a/src/countdown/index.jsx
+++ b/src/countdown/index.jsx
@@ -6,7 +6,7 @@ import differenceInDays from 'date-fns/difference_in_calendar_days';
 import isBefore from 'date-fns/is_before';
 import classnames from 'classnames';
 
-const ExpiryDate = ({ expiry, unit, showUrgent }) => {
+const Countdown = ({ expiry, unit, showUrgent }) => {
   const now = new Date();
 
   const diff = {
@@ -32,9 +32,9 @@ const ExpiryDate = ({ expiry, unit, showUrgent }) => {
   );
 };
 
-ExpiryDate.defaultProps = {
+Countdown.defaultProps = {
   unit: 'month',
   showUrgent: 3
 };
 
-export default ExpiryDate;
+export default Countdown;

--- a/src/countdown/index.jsx
+++ b/src/countdown/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Snippet } from '../';
+import differenceInMonths from 'date-fns/difference_in_months';
+import differenceInWeeks from 'date-fns/difference_in_weeks';
+import differenceInDays from 'date-fns/difference_in_calendar_days';
+import isBefore from 'date-fns/is_before';
+import classnames from 'classnames';
+
+const ExpiryDate = ({ expiry, unit, showUrgent }) => {
+  const now = new Date();
+
+  const diff = {
+    day: differenceInDays(expiry, now),
+    week: differenceInWeeks(expiry, now),
+    month: differenceInMonths(expiry, now)
+  };
+
+  const displayUnit = diff['day'] <= 7 ? 'day' : (diff['day'] <= 28 ? 'week' : 'month');
+  const displayDiff = displayUnit === 'day' ? diff[displayUnit] : diff[displayUnit] + 1;
+  const urgent = diff[unit] <= showUrgent;
+
+  let contentKey = displayDiff === 1 ? 'diff.singular' : 'diff.plural';
+
+  if (isBefore(expiry, now)) {
+    contentKey = 'diff.expired';
+  }
+
+  return (
+    <span className={classnames('notice', { urgent })}>
+      <Snippet diff={displayDiff} unit={displayUnit}>{contentKey}</Snippet>
+    </span>
+  );
+};
+
+ExpiryDate.defaultProps = {
+  unit: 'month',
+  showUrgent: 3
+};
+
+export default ExpiryDate;

--- a/src/countdown/index.spec.jsx
+++ b/src/countdown/index.spec.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Countdown from './';
+import Snippet from '../snippet';
+import endOfTomorrow from 'date-fns/end_of_tomorrow';
+import addWeeks from 'date-fns/add_weeks';
+import addMonths from 'date-fns/add_months';
+
+describe('<Countdown />', () => {
+
+  test('shows an expired message if provided date is in the past', () => {
+    const wrapper = shallow(<Countdown expiry={'2017-01-01'} />);
+    expect(wrapper.find(Snippet).props().children).toEqual('diff.expired');
+  });
+
+  test('shows urgent 1 day left message if the expiry date is tomorrow', () => {
+    const wrapper = shallow(<Countdown expiry={endOfTomorrow()} />);
+    expect(wrapper.find(Snippet).length).toBe(1);
+    expect(wrapper.find(Snippet).props().children).toEqual('diff.singular');
+    expect(wrapper.find('span').props().className).toMatch('urgent');
+    expect(wrapper.find(Snippet).props().unit).toEqual('day');
+    expect(wrapper.find(Snippet).props().diff).toEqual(1);
+  });
+
+  test('shows less than x weeks left if the expiry date is greater than 1 week but less than a month', () => {
+    const wrapper = shallow(<Countdown expiry={addWeeks(new Date(), 2)} />);
+    expect(wrapper.find(Snippet).length).toBe(1);
+    expect(wrapper.find(Snippet).props().unit).toEqual('week');
+    expect(wrapper.find(Snippet).props().children).toEqual('diff.plural');
+  });
+
+  test('shows less than x months left if the expiry date is greater than 1 month but less than a year', () => {
+    const wrapper = shallow(<Countdown expiry={addMonths(new Date(), 9)} />);
+    expect(wrapper.find(Snippet).length).toBe(1);
+    expect(wrapper.find(Snippet).props().unit).toEqual('month');
+    expect(wrapper.find(Snippet).props().children).toEqual('diff.plural');
+  });
+
+});

--- a/src/countdown/index.spec.jsx
+++ b/src/countdown/index.spec.jsx
@@ -36,4 +36,9 @@ describe('<Countdown />', () => {
     expect(wrapper.find(Snippet).props().children).toEqual('diff.plural');
   });
 
+  test('does not display if showNotice is less than the current time difference', () => {
+    const wrapper = shallow(<Countdown expiry={addMonths(new Date(), 9)} unit='month' showNotice={7} />);
+    expect(wrapper.find('span').length).toBe(0);
+  });
+
 });

--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -1,8 +1,5 @@
 import React, { Fragment } from 'react';
 import { Countdown } from '../';
-import differenceInMonths from 'date-fns/difference_in_months';
-import differenceInWeeks from 'date-fns/difference_in_weeks';
-import differenceInDays from 'date-fns/difference_in_calendar_days';
 import format from 'date-fns/format';
 
 const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice }) => {
@@ -14,21 +11,10 @@ const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice }) 
     expiry = date;
   }
 
-  const now = new Date();
-
-  const diff = {
-    day: differenceInDays(expiry, now),
-    week: differenceInWeeks(expiry, now),
-    month: differenceInMonths(expiry, now)
-  };
-
   return (
     <Fragment>
       { format(date, dateFormat) }
-      {
-        diff[unit] <= showNotice &&
-          <Countdown expiry={expiry} unit={unit} showUrgent={showUrgent} />
-      }
+      <Countdown expiry={expiry} unit={unit} showUrgent={showUrgent} showNotice={showNotice} />
     </Fragment>
   );
 };
@@ -37,7 +23,7 @@ ExpiryDate.defaultProps = {
   dateFormat: 'DD MMMM YYYY',
   unit: 'month',
   showUrgent: 3,
-  showNotice: 11
+  showNotice: true
 };
 
 export default ExpiryDate;

--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -7,7 +7,7 @@ import isBefore from 'date-fns/is_before';
 import format from 'date-fns/format';
 import classnames from 'classnames';
 
-const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice }) => {
+const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice, showDate }) => {
   if (!date) {
     return null;
   }
@@ -26,19 +26,17 @@ const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice }) 
 
   const displayUnit = diff['day'] <= 7 ? 'day' : (diff['day'] <= 28 ? 'week' : 'month');
   const displayDiff = displayUnit === 'day' ? diff[displayUnit] : diff[displayUnit] + 1;
-  const urgent = displayDiff <= showUrgent;
+  const urgent = diff[unit] <= showUrgent;
 
-  let contentKey = 'diff.standard';
+  let contentKey = displayDiff === 1 ? 'diff.singular' : 'diff.plural';
 
   if (isBefore(expiry, now)) {
     contentKey = 'diff.expired';
-  } else if (urgent) {
-    contentKey = displayDiff === 1 ? 'diff.singular' : 'diff.plural';
   }
 
   return (
     <Fragment>
-      {format(date, dateFormat)}
+      { showDate && format(date, dateFormat) }
       {diff[unit] <= showNotice && (
         <span className={classnames('notice', { urgent })}>
           <Snippet diff={displayDiff} unit={displayUnit}>{contentKey}</Snippet>
@@ -52,7 +50,8 @@ ExpiryDate.defaultProps = {
   dateFormat: 'DD MMMM YYYY',
   unit: 'month',
   showUrgent: 3,
-  showNotice: 11
+  showNotice: 11,
+  showDate: true
 };
 
 export default ExpiryDate;

--- a/src/expiry-date/index.jsx
+++ b/src/expiry-date/index.jsx
@@ -1,13 +1,11 @@
 import React, { Fragment } from 'react';
-import { Snippet } from '../';
+import { Countdown } from '../';
 import differenceInMonths from 'date-fns/difference_in_months';
 import differenceInWeeks from 'date-fns/difference_in_weeks';
 import differenceInDays from 'date-fns/difference_in_calendar_days';
-import isBefore from 'date-fns/is_before';
 import format from 'date-fns/format';
-import classnames from 'classnames';
 
-const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice, showDate }) => {
+const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice }) => {
   if (!date) {
     return null;
   }
@@ -24,24 +22,13 @@ const ExpiryDate = ({ date, expiry, dateFormat, unit, showUrgent, showNotice, sh
     month: differenceInMonths(expiry, now)
   };
 
-  const displayUnit = diff['day'] <= 7 ? 'day' : (diff['day'] <= 28 ? 'week' : 'month');
-  const displayDiff = displayUnit === 'day' ? diff[displayUnit] : diff[displayUnit] + 1;
-  const urgent = diff[unit] <= showUrgent;
-
-  let contentKey = displayDiff === 1 ? 'diff.singular' : 'diff.plural';
-
-  if (isBefore(expiry, now)) {
-    contentKey = 'diff.expired';
-  }
-
   return (
     <Fragment>
-      { showDate && format(date, dateFormat) }
-      {diff[unit] <= showNotice && (
-        <span className={classnames('notice', { urgent })}>
-          <Snippet diff={displayDiff} unit={displayUnit}>{contentKey}</Snippet>
-        </span>
-      )}
+      { format(date, dateFormat) }
+      {
+        diff[unit] <= showNotice &&
+          <Countdown expiry={expiry} unit={unit} showUrgent={showUrgent} />
+      }
     </Fragment>
   );
 };
@@ -50,8 +37,7 @@ ExpiryDate.defaultProps = {
   dateFormat: 'DD MMMM YYYY',
   unit: 'month',
   showUrgent: 3,
-  showNotice: 11,
-  showDate: true
+  showNotice: 11
 };
 
 export default ExpiryDate;

--- a/src/expiry-date/index.spec.jsx
+++ b/src/expiry-date/index.spec.jsx
@@ -1,40 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ExpiryDate from './';
-import Snippet from '../snippet';
-import endOfTomorrow from 'date-fns/end_of_tomorrow';
-import addWeeks from 'date-fns/add_weeks';
-import addMonths from 'date-fns/add_months';
+import Countdown from '../countdown';
 
 describe('<ExpiryDate />', () => {
 
-  test('shows an expired message if provided date is in the past', () => {
+  test('shows a message if provided date is in the past', () => {
     const wrapper = shallow(<ExpiryDate date={'2017-01-01'} />);
-    expect(wrapper.find(Snippet).length).toBe(1);
-    expect(wrapper.find(Snippet).props().children).toEqual('diff.expired');
-  });
-
-  test('shows urgent 1 day left message if the expiry date is tomorrow', () => {
-    const wrapper = shallow(<ExpiryDate date={endOfTomorrow()} />);
-    expect(wrapper.find(Snippet).length).toBe(1);
-    expect(wrapper.find(Snippet).props().children).toEqual('diff.singular');
-    expect(wrapper.find('span').props().className).toMatch('urgent');
-    expect(wrapper.find(Snippet).props().unit).toEqual('day');
-    expect(wrapper.find(Snippet).props().diff).toEqual(1);
-  });
-
-  test('shows less than x weeks left if the expiry date is greater than 1 week but less than a month', () => {
-    const wrapper = shallow(<ExpiryDate date={addWeeks(new Date(), 2)} />);
-    expect(wrapper.find(Snippet).length).toBe(1);
-    expect(wrapper.find(Snippet).props().unit).toEqual('week');
-    expect(wrapper.find(Snippet).props().children).toEqual('diff.plural');
-  });
-
-  test('shows less than x months left if the expiry date is greater than 1 month but less than a year', () => {
-    const wrapper = shallow(<ExpiryDate date={addMonths(new Date(), 9)} />);
-    expect(wrapper.find(Snippet).length).toBe(1);
-    expect(wrapper.find(Snippet).props().unit).toEqual('month');
-    expect(wrapper.find(Snippet).props().children).toEqual('diff.standard');
+    expect(wrapper.find(Countdown).length).toBe(1);
   });
 
 });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,6 +11,7 @@ export { default as Controls } from './controls';
 export { default as ControlBar } from './control-bar';
 export { default as ConditionalReveal } from './conditional-reveal';
 export { default as Conditions } from './conditions';
+export { default as Countdown } from './countdown';
 export { default as Datatable } from './datatable';
 export { default as Diff } from './diff';
 export { default as DiffText } from './diff-text';


### PR DESCRIPTION
Sometimes we only want to display the time remaining and not the actual date of expiry.

Simplifies the content to either singular (1 day left), plural (2 weeks left) or expired (Expired). The "standard" content (previously displayed when not urgent) always assumed multiple units which might not be the case (e.g. 1 days left).