### PR TITLE
showNotice should default to true

### DIFF
--- a/src/countdown/index.jsx
+++ b/src/countdown/index.jsx
@@ -38,7 +38,7 @@ const Countdown = ({ expiry, unit, showNotice, showUrgent }) => {
 
 Countdown.defaultProps = {
   unit: 'month',
-  showNotice: 11,
+  showNotice: true,
   showUrgent: 3
 };
 


### PR DESCRIPTION
It defaults to true in `<ExpiryDate>` but I missed it here.