### PR TITLE
Link improvements

### DIFF
--- a/src/breadcrumbs/breadcrumbs.spec.jsx
+++ b/src/breadcrumbs/breadcrumbs.spec.jsx
@@ -22,14 +22,8 @@ describe('<Breadcrumbs />', () => {
     const crumbs = ['dashboard'];
     const wrapper = shallow(<Breadcrumbs crumbs={crumbs} />);
 
-    test('renders 1 <Breadcrumb /> elements', () => {
-      expect(wrapper.find(Breadcrumb).length).toBe(1);
-    });
-
-    test('passes a label crumb to the <Breadcrumb />', () => {
-      const el = wrapper.find(Breadcrumb).last();
-      expect(el.props().crumb).toEqual('dashboard');
-      expect(el.props().link).toEqual(false);
+    test('doesn\'t render any elements', () => {
+      expect(wrapper.find(Breadcrumb).length).toBe(0);
     });
   });
 

--- a/src/breadcrumbs/index.jsx
+++ b/src/breadcrumbs/index.jsx
@@ -22,7 +22,7 @@ export const Breadcrumb = ({ crumb = {}, link = false }) => {
   );
 };
 
-const renderNull = crumbs => !crumbs || !crumbs.length || !Array.isArray(crumbs);
+const renderNull = crumbs => !crumbs || !crumbs.length || crumbs.length === 1 || !Array.isArray(crumbs);
 
 const Breadcrumbs = ({ crumbs }) => {
   if (renderNull(crumbs)) {

--- a/src/breadcrumbs/index.jsx
+++ b/src/breadcrumbs/index.jsx
@@ -22,7 +22,7 @@ export const Breadcrumb = ({ crumb = {}, link = false }) => {
   );
 };
 
-const renderNull = crumbs => !crumbs || !crumbs.length || crumbs.length === 1 || !Array.isArray(crumbs);
+const renderNull = crumbs => !crumbs || !Array.isArray(crumbs) || crumbs.length < 2;
 
 const Breadcrumbs = ({ crumbs }) => {
   if (renderNull(crumbs)) {

--- a/src/licence-status-banner/index.jsx
+++ b/src/licence-status-banner/index.jsx
@@ -71,7 +71,7 @@ class LicenceStatusBanner extends Component {
           {
             isInactiveVersion && <Fragment>
               <p><Snippet>invalidLicence.summary.ppl_active</Snippet></p>
-              <p><Link page="project.version.read" versionId={this.props.licence.granted.id} label={<Snippet>{'invalidLicence.view'}</Snippet>} /></p>
+              <p><Link page="projectVersion" versionId={this.props.licence.granted.id} label={<Snippet>{'invalidLicence.view'}</Snippet>} /></p>
             </Fragment>
           }
           {

--- a/src/licence-status-banner/index.jsx
+++ b/src/licence-status-banner/index.jsx
@@ -71,7 +71,7 @@ class LicenceStatusBanner extends Component {
           {
             isInactiveVersion && <Fragment>
               <p><Snippet>invalidLicence.summary.ppl_active</Snippet></p>
-              <p><Link page="projectVersion" versionId={this.props.licence.granted.id} label={<Snippet>{'invalidLicence.view'}</Snippet>} /></p>
+              <p><Link page="project.version.read" versionId={this.props.licence.granted.id} label={<Snippet>{'invalidLicence.view'}</Snippet>} /></p>
             </Fragment>
           }
           {

--- a/src/link/index.jsx
+++ b/src/link/index.jsx
@@ -6,6 +6,19 @@ const replace = params => fragment => {
   return fragment[0] === ':' ? params[fragment.substr(1)] : fragment;
 };
 
+function getUrl(urls, parts, replacer) {
+  let item = urls;
+  const sections = parts.map(part => {
+    const section = get(item, part);
+    if (!section) {
+      throw new Error(`Unknown link target: ${parts.join('.')}`);
+    }
+    item = section.routes;
+    return section.path.split('/').map(replacer).join('/');
+  });
+  return sections.join('');
+}
+
 const Link = ({
   url,
   urls,
@@ -16,13 +29,11 @@ const Link = ({
   ...props
 }) => {
   if (page) {
-    const href = get(urls, page);
-    if (typeof href !== 'string') {
-      throw new Error(`Unknown link target: ${page}`);
-    }
+    const parts = page.split('.');
     const replacer = replace(props);
-    url = href.split('/').map(replacer).join('/');
-    return <a className={className} href={url}>{label}</a>;
+    const href = getUrl(urls, parts, replacer);
+
+    return <a className={className} href={href}>{label}</a>;
   } else {
     return <a className={className} href={`${url}/${path}`}>{label}</a>;
   }

--- a/src/snippet/index.jsx
+++ b/src/snippet/index.jsx
@@ -31,9 +31,11 @@ export const Snippet = ({ content, children, optional, fallback, ...props }) => 
 };
 
 const mapStateToProps = ({
-  static: { content, establishment, profile }, model
+  static: staticProps,
+  model
 }) => ({
-  content, establishment, profile, model
+  ...staticProps,
+  model
 });
 
 export default connect(mapStateToProps)(Snippet);


### PR DESCRIPTION
* Updated link component to render multi-part paths, split on `.` and use replacer on each part
* Pass everything from static to snippet for improved breadcrumb rendering
* Dont render only one breadcrumbt