### PR TITLE
Long <dt>'s were causing staggering indents

### DIFF
--- a/styles/_description-lists.scss
+++ b/styles/_description-lists.scss
@@ -17,14 +17,25 @@ dl {
   }
 
   &.inline {
-    @extend .govuk-grid-row;
-
-    > dt {
-      @extend .govuk-grid-column-one-third;
+    dt {
+      float: left;
+      margin-right: 5%;
+      max-width: 30%;
     }
 
-    > dd {
-      @extend .govuk-grid-column-two-thirds;
+    dd {
+      margin-left: 35%;
+      margin-bottom: $govuk-gutter;
+
+      ul {
+        padding-left: 1em;
+      }
+    }
+
+    dd::after {
+      content: " ";
+      display: block;
+      clear: left;
     }
   }
 }


### PR DESCRIPTION
The definition list was not displaying properly if the titles were long, it would start to indent the next item in the list.