### PR TITLE
Prevent double form submission

### DIFF
--- a/src/form/form.jsx
+++ b/src/form/form.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { Snippet, Fieldset } from '../';
 
 const Form = ({
@@ -10,11 +10,20 @@ const Form = ({
   schema,
   ...props
 }) => {
+
+  const [disabled, setDisabled] = useState(false);
+  const onSubmit = e => {
+    if (disabled) {
+      e.preventDefault();
+    }
+    setTimeout(() => setDisabled(true), 0);
+  };
+
   const formFields = (
     <Fragment>
       <Fieldset schema={schema} { ...props } />
       {
-        submit && <button type="submit" className="govuk-button"><Snippet>buttons.submit</Snippet></button>
+        submit && <button type="submit" className="govuk-button" disabled={disabled}><Snippet>buttons.submit</Snippet></button>
       }
     </Fragment>
   );
@@ -24,6 +33,7 @@ const Form = ({
       method="POST"
       noValidate
       className={className}
+      onSubmit={onSubmit}
       encType={Object.values(schema).map(s => s.inputType).includes('inputFile') ? 'multipart/form-data' : null}
     >
       <input type="hidden" name="_csrf" value={csrfToken} />


### PR DESCRIPTION
Disables the submit button on a form once it has been submitted. This prevents actions being carried out twice when a user double clicks on a button.

The `setTimeout` is required becuse if the button is disabled immediately then the form is not submitted.