### PR TITLE
Improve error message for background loading failure

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -52,7 +52,7 @@ const fetchItems = (url, dispatch) => {
       dispatch(receiveItems({ rows, count, totalCount }));
     })
     .catch(err => {
-      dispatch(showNotification({ message: err.message, type: 'error' }));
+      dispatch(showNotification({ message: 'Connection error. Please wait a moment and try again.', type: 'error' }));
       dispatch(requestFailed());
       throw err;
     });


### PR DESCRIPTION
The default error message thrown by the fetch function is "Failed to fetch" which is deemed insufficiently user friendly.

Replace this with a custom message when background fetching fails.