### PR TITLE
Remove cursor: pointer from expanded table rows

### DIFF
--- a/src/datatable/index.scss
+++ b/src/datatable/index.scss
@@ -81,8 +81,6 @@
   }
 
   tr.expanded-content {
-    cursor: pointer;
-
     .govuk-grid-column-one-quarter {
       border-right: 1px solid #ccc;
     }


### PR DESCRIPTION
This was adding a link-style cursor to the entire content of expanded table rows, which was not right.