### PR TITLE
Extend datatable fetch timeout

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,6 @@
 const { showNotification } = require('./notification/actions');
 
-const FETCH_TIMEOUT = 5000;
+const FETCH_TIMEOUT = 15000;
 
 const requestItems = () => ({
   type: 'REQUEST_ITEMS'


### PR DESCRIPTION
Some requests are super slow, so rather than failing totally let them work, but be slow.