### PR TITLE
Feature - React Markdown wrapper

### DIFF
--- a/src/conditions/index.jsx
+++ b/src/conditions/index.jsx
@@ -1,6 +1,5 @@
 import React, { Component, Fragment } from 'react';
-import ReactMarkdown from 'react-markdown';
-import { Form } from '../';
+import { Form, Markdown } from '../';
 
 class Conditions extends Component {
 
@@ -34,7 +33,7 @@ class Conditions extends Component {
             : (
               <Fragment>
                 {
-                  conditions && <ReactMarkdown>{ conditions }</ReactMarkdown>
+                  conditions && <Markdown>{ conditions }</Markdown>
                 }
                 {
                   canUpdate && <a href="#" onClick={e => this.toggleEdit(e)}>{conditions ? updateLabel : addLabel }</a>

--- a/src/editable-field/index.jsx
+++ b/src/editable-field/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import { TextArea, Button } from '@ukhomeoffice/react-components';
-import ReactMarkdown from 'react-markdown';
+import { Markdown } from '../';
 
 export default function EditableField({
   label,
@@ -59,7 +59,7 @@ export default function EditableField({
     <div className="govuk-form-group editable-field">
       <h2>{ label }</h2>
       { showDiff && currentLabel && <h3>{currentLabel}</h3> }
-      <ReactMarkdown>{ format ? format(original) : original }</ReactMarkdown>
+      <Markdown>{ format ? format(original) : original }</Markdown>
       {
         showDiff && (
           <Fragment>
@@ -77,7 +77,7 @@ export default function EditableField({
                     autoExpand={true}
                   />
                 )
-                : <ReactMarkdown className="highlight">{proposedContent || 'None'}</ReactMarkdown>
+                : <Markdown className="highlight">{proposedContent || 'None'}</Markdown>
             }
           </Fragment>
         )

--- a/src/field/index.jsx
+++ b/src/field/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { TextArea } from '@ukhomeoffice/react-components';
-import ReactMarkdown from 'react-markdown';
+import { Markdown } from '../';
 
 class Field extends Component {
   constructor (props) {
@@ -35,7 +35,7 @@ class Field extends Component {
     return (
       <div className="field">
         <h2>{ title }</h2>
-        <ReactMarkdown>{ content }</ReactMarkdown>
+        <Markdown>{ content }</Markdown>
         {
           this.props.editable && (!this.state || this.state.editing) && (
             <TextArea

--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -3,9 +3,8 @@ import map from 'lodash/map';
 import without from 'lodash/without';
 import castArray from 'lodash/castArray';
 import classnames from 'classnames';
-import ReactMarkdown from 'react-markdown';
 import { TextArea, Input, CheckboxGroup, RadioGroup, Select, DateInput } from '@ukhomeoffice/react-components';
-import { Snippet, ConditionalReveal, SpeciesSelector, ApplicationConfirm, RestrictionsField } from '../';
+import { Snippet, ConditionalReveal, SpeciesSelector, ApplicationConfirm, RestrictionsField, Markdown } from '../';
 
 const fields = {
   inputText: props => <Input { ...props } />,
@@ -24,7 +23,7 @@ const fields = {
   text: props => (
     <div className={classnames('govuk-form-group', props.name)}>
       <h3>{ props.label }</h3>
-      <ReactMarkdown>{ props.format ? props.format(props.value) : props.value }</ReactMarkdown>
+      <Markdown>{ props.format ? props.format(props.value) : props.value }</Markdown>
     </div>
   )
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -37,6 +37,7 @@ export { default as JoinAcronyms } from './join-acronyms';
 export { default as LicenceStatusBanner } from './licence-status-banner';
 export { default as Link } from './link';
 export { default as LinkFilter } from './link-filter';
+export { default as Markdown } from './markdown';
 export { default as ModelSummary } from './model-summary';
 export { default as MultiInput } from './multi-input';
 export { default as Notification } from './notification';

--- a/src/markdown/index.jsx
+++ b/src/markdown/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
+function RenderLink({ href, children }) {
+  return <span>[{ children }]({ href })</span>;
+}
+
+export default function Markdown({ children, links = false, ...props }) {
+  return <ReactMarkdown renderers={!links && { link: RenderLink }} {...props}>{ children }</ReactMarkdown>;
+}


### PR DESCRIPTION
* Added Markdown component which wraps ReactMarkdown, replacing all links with original text
* Use wrapper in place of react markdown everywhere except snippet