### PR TITLE
Bugfix - content mismatch errors

### DIFF
--- a/src/acronym/index.jsx
+++ b/src/acronym/index.jsx
@@ -5,6 +5,6 @@ const Acronym = ({
   children
 }) => dictionary[children]
   ? <abbr title={dictionary[children]}>{children}</abbr>
-  : children;
+  : <span>{ children }</span>;
 
 export default Acronym;

--- a/src/snippet/index.jsx
+++ b/src/snippet/index.jsx
@@ -16,16 +16,17 @@ export const Snippet = ({ content, children, optional, fallback, ...props }) => 
   }
   const source = trim(render(str, props));
 
-  const isRootParagraph = (node, i, parent) => {
-    return node.type !== 'paragraph' || parent.type !== 'root' || parent.children.length !== 1;
-  };
+  function wrapInSpanIfOnlyChild({ children, parentChildCount }) {
+    return parentChildCount > 1
+      ? <p>{ children }</p>
+      : <span>{ children }</span>;
+  }
 
   return (
     <ReactMarkdown
       source={source}
-      renderers={{ root: Fragment }}
-      allowNode={isRootParagraph}
-      unwrapDisallowed={true}
+      includeNodeIndex={true}
+      renderers={{ root: Fragment, paragraph: wrapInSpanIfOnlyChild }}
     />
   );
 };


### PR DESCRIPTION
* updated snippet logic to render a span in place of a p if parent has multiple children
* wrap empty acronym in span