### PR TITLE
Include custom querystring params in csv download

### DIFF
--- a/src/csv-download/index.jsx
+++ b/src/csv-download/index.jsx
@@ -3,11 +3,11 @@ import { useSelector } from 'react-redux';
 import { stringify } from 'qs';
 import get from 'lodash/get';
 
-export default function CSVDownloadLink ({ label = 'Download this data (.csv)' }) {
-  const query = useSelector(state => {
+export default function CSVDownloadLink ({ label = 'Download this data (.csv)', query = {} }) {
+  const querystring = useSelector(state => {
     const filters = get(state, 'datatable.filters.active');
     const sort = get(state, 'datatable.sort');
-    return { filters, sort, csv: 1 };
+    return { filters, sort, csv: 1, ...query };
   });
-  return <a href={`?${stringify(query)}`} className="download">{ label }</a>;
+  return <a href={`?${stringify(querystring)}`} className="download">{ label }</a>;
 }


### PR DESCRIPTION
As well as the default params inherited from datatables, also allow additional custom query string parameters to be defined when downloading CSV reports.