### PR TITLE
Remove extra hanging } from Link

### DIFF
--- a/src/link/index.jsx
+++ b/src/link/index.jsx
@@ -42,7 +42,7 @@ const Link = ({
 
     return <a className={className} href={`${href}${qs ? '?' + qs : ''}`}>{label}</a>;
   } else {
-    return <a className={className} href={`${url}/${path}${qs ? '?' + qs : ''}}`}>{label}</a>;
+    return <a className={className} href={`${url}/${path}${qs ? '?' + qs : ''}`}>{label}</a>;
   }
 };
 


### PR DESCRIPTION
There was one too many `}` in the link href which meant it was leaving an extra `}` on the end of the url when rendered.