### PR TITLE
Use CSS grids for filter component

### DIFF
--- a/src/filters/index.jsx
+++ b/src/filters/index.jsx
@@ -99,10 +99,10 @@ export default function Filters({ formatters }) {
           type="form"
           onApply={emitChange}
         >
-          <div className="filters govuk-grid-row">
+          <div className="filters">
             {
               map(opts, ({ values, format }, key) =>
-                <div key={key} className="govuk-grid-column-one-third">
+                <div key={key} className="filter">
                   <OptionSelect
                     title={<Snippet>{`fields.${key}.label`}</Snippet>}
                     defaultOpen={Object.keys(activeFilters).includes(key)}

--- a/src/filters/index.scss
+++ b/src/filters/index.scss
@@ -14,6 +14,14 @@
       content: "\25ba";
     }
   }
+
+  @include govuk-media-query($from: desktop) {
+    .filters {
+      display: grid;
+      grid: auto-flow / 1fr 1fr 1fr;
+      grid-column-gap: $govuk-gutter;
+    }
+  }
 }
 
 .js-container-head {


### PR DESCRIPTION
The govuk grid doesn't work too well with a dynamic number of filter boxes, so use CSS grids instead.

Add a media query so that they stack below a certain width.