### PR TITLE
Bugfix - clear autocomplete on blur

### DIFF
--- a/src/autocomplete/index.jsx
+++ b/src/autocomplete/index.jsx
@@ -1,9 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import AccessibleAutocomplete from 'accessible-autocomplete/react';
 import { InputWrapper } from '@ukhomeoffice/react-components';
 
 export default function AutoComplete(props) {
   const [value, setValue] = useState(props.value);
+  const defaultValue = (props.options.find(opt => opt.value === props.value) || {}).label;
+
+  useEffect(() => {
+    const inputElement = window.document.querySelector(`input#${props.name}`);
+
+    function onBlur(event) {
+      const val = event.target.value;
+      if (!val) {
+        setValue('');
+      }
+    }
+
+    inputElement.addEventListener('blur', onBlur);
+
+    return () => {
+      inputElement.removeEventListener('blur', onBlur);
+    };
+  });
 
   function suggest (query, syncResults) {
     syncResults(query
@@ -27,6 +45,8 @@ export default function AutoComplete(props) {
           suggestion: renderLabel
         }}
         onConfirm={option => setValue(option ? option.value : '')}
+        confirmOnBlur={false}
+        defaultValue={defaultValue}
       />
     </InputWrapper>
   );


### PR DESCRIPTION
* Added blur event listener to autocomplete, if value is null then clear value sent in hidden input. This is necessary because of onConfirm not working as expected