### PR TITLE
Hide random status pop-ups

### DIFF
--- a/src/autocomplete/index.scss
+++ b/src/autocomplete/index.scss
@@ -10,6 +10,10 @@ span[id*="__assistiveHint"] {
 
 .autocomplete__wrapper {
   margin-bottom: $govuk-gutter;
+
+  [role="status"] {
+    display: none;
+  }
 }
 
 .govuk-form-group--error .autocomplete__input {


### PR DESCRIPTION
These are intended to be hidden using inline style props, but our CSP prevents this from being applied. Apply a nuclear fix instead.