### PR TITLE
Disable "link references" in Markdown

### DIFF
--- a/src/markdown/index.jsx
+++ b/src/markdown/index.jsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 function RenderLink({ href, children }) {
-  return <span>[{ children }]({ href })</span>;
+  return <Fragment>[{ children }]({ href })</Fragment>;
+}
+function RenderLinkReference({ children }) {
+  return <Fragment>[{ children }]</Fragment>;
 }
 
+const renderers = {
+  link: RenderLink,
+  linkReference: RenderLinkReference
+};
+
 export default function Markdown({ children, links = false, ...props }) {
-  return <ReactMarkdown renderers={!links && { link: RenderLink }} {...props}>{ children }</ReactMarkdown>;
+  return <ReactMarkdown renderers={!links && renderers} {...props}>{ children }</ReactMarkdown>;
 }


### PR DESCRIPTION
Markdown input of the type `[content in square brackets]` is interpreted as a `linkReference` rather than a `link` so our previous approach to disabling links did not catch that case and rendered content as an `<a href>...</a>`.

Include a custom renderer for `linkReference` types which leaves the content as-is.