### PR TITLE
Bugfix - applychanges link filter href

### DIFF
--- a/src/apply-changes/index.jsx
+++ b/src/apply-changes/index.jsx
@@ -41,11 +41,20 @@ ApplyChanges.defaultProps = {
 };
 
 const mapStateToProps = ({
-  datatable: { filters: { active: filters }, sort, pagination: { page } }
+  datatable: { filters: { active: basefilters }, sort, pagination: { page } }
 }, {
-  query = {}
+  query = {},
+  filters = {}
 }) => ({
-  query: Object.assign({}, { filters, sort, page: page + 1 }, query)
+  query: {
+    filters: {
+      ...basefilters,
+      ...filters
+    },
+    sort,
+    page: page + 1,
+    ...query
+  }
 });
 
 export default connect(mapStateToProps)(ApplyChanges);


### PR DESCRIPTION
* this was being set from the current datatable state so all links were being rendered with the same href. Updated to extend the state with custom filters passed in from link filter