### PR TITLE
Accessibility - search label

### DIFF
--- a/src/search/index.jsx
+++ b/src/search/index.jsx
@@ -31,6 +31,7 @@ export class Search extends Component {
             id={name}
             name={name}
             type="text"
+            aria-labelledby={this.props.labelledBy}
             value={ this.state ? this.state.value : this.props.filter }
             onChange={e => this.setState({ value: e.target.value })}
           />


### PR DESCRIPTION
Provide an optional aria-labelledby attribute for search components which do not have a label (dashboard search is labelled by a h2)