### PR TITLE
Handle case where species selector value is `null`

### DIFF
--- a/src/species-selector/index.jsx
+++ b/src/species-selector/index.jsx
@@ -12,7 +12,7 @@ const ALL_SPECIES = flatten(values(groups).map(g => g.types));
 
 export default function SpeciesSelector(props) {
   const parts = partition(props.value, s => ALL_SPECIES.includes(s));
-  const [value, setValue] = useState(props.value);
+  const [value, setValue] = useState(props.value || []);
   const [presetSpecies, setPresetSpecies] = useState(parts[0]);
   const [otherSpecies, setOtherSpecies] = useState(parts[1]);
 


### PR DESCRIPTION
Default the value to an empty array if a null value is passed as the value prop.