### PR TITLE
Fix query string for API driven autocomplete

### DIFF
--- a/src/autocomplete/index.jsx
+++ b/src/autocomplete/index.jsx
@@ -36,7 +36,7 @@ export default function AutoComplete(props) {
     if (!query) {
       return syncResults([]);
     }
-    window.fetch(`${apiPath}?${query}`)
+    window.fetch(`${apiPath}?search=${query}`)
       .then(res => res.json())
       .then(results => {
         syncResults(results || []);


### PR DESCRIPTION
The parameter sent in the query string did not have a name, where the server endpoint expected it to be named `search`.