### PR TITLE
Prevent filtering from clearing search

### DIFF
--- a/src/filters/actions.js
+++ b/src/filters/actions.js
@@ -1,6 +1,7 @@
 const { queryStringFromState } = require('../utils');
 const { fetchItems } = require('../actions');
 const merge = require('lodash/merge');
+const get = require('lodash/get');
 
 const setFilters = filters => ({
   type: 'SET_FILTERS',
@@ -9,9 +10,16 @@ const setFilters = filters => ({
 
 const changeFilters = filters => (dispatch, getState) => {
   const state = getState();
+  const searchFilter = get(state, 'datatable.filters.active[*]');
+
+  if (searchFilter) {
+    filters['*'] = searchFilter;
+  }
+
   const query = queryStringFromState(merge({}, state, {
     datatable: { filters: { active: filters } }
   }));
+
   return fetchItems(`${state.static.url}?${query}`, dispatch)
     .then(() => dispatch(setFilters(filters)));
 };

--- a/src/filters/index.jsx
+++ b/src/filters/index.jsx
@@ -55,7 +55,7 @@ export default function Filters({ formatters }) {
   }
 
   function clearFilters() {
-    onFiltersChange(null);
+    onFiltersChange({});
     setActiveFilters({});
   }
 


### PR DESCRIPTION
Unticking a filter or clearing all the filters was leaving the search term in the search box but removing it from the search query. It should only remove the filter.