### PR TITLE
Fix onChange event param from AutoComplete

### DIFF
--- a/src/autocomplete/index.jsx
+++ b/src/autocomplete/index.jsx
@@ -29,7 +29,7 @@ export default function AutoComplete(props) {
   });
 
   useEffect(() => {
-    typeof props.onChange === 'function' && props.onChange(value);
+    typeof props.onChange === 'function' && props.onChange({ target: { value } });
   }, [value]);
 
   function simpleSearch (query, syncResults) {


### PR DESCRIPTION
The default listeners created by a Field component expect change events to be called with an argument with the structure `event.target.value`.

Ensure that when an AutoComplete component emits an onChange handler that the parameter matches this structure.