### PR TITLE
Remove margin from sticky header when it's sticky

### DIFF
--- a/src/document-header/index.scss
+++ b/src/document-header/index.scss
@@ -7,6 +7,10 @@
     position: -webkit-sticky;
     position: sticky;
     top: 0;
+
+    .document-header {
+      margin-bottom: 0;
+    }
   }
 }
 


### PR DESCRIPTION
When the user scrolls down the page on a page with a sticky header the bottom margin on the header bar prevents links in the 30px immediately below the document header from being clickable because they are overlapped by the bottom margin of the header bar.