### PR TITLE
Better filter summary labels for search / filter results

### DIFF
--- a/src/filter-summary/index.jsx
+++ b/src/filter-summary/index.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-const FilterSummary = ({ total, filtered, filteredLabel, allShowingLabel, recordType = 'results' }) => {
-  filteredLabel = filteredLabel || `${filtered} results`;
-  allShowingLabel = allShowingLabel || `All ${total} ${recordType}`;
+const FilterSummary = ({ total, filtered, filteredLabel, allShowingLabel, resultType = 'results' }) => {
+  filteredLabel = filteredLabel || `${filtered} result${filtered === 1 ? '' : 's'}`;
+  allShowingLabel = allShowingLabel || `All ${total} ${resultType}`;
 
   return (
     <h2 className="filter-summary">

--- a/src/filter-summary/index.jsx
+++ b/src/filter-summary/index.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-const FilterSummary = ({
-  total,
-  filtered,
-  filteredLabel = `Showing ${filtered} of ${total} results`,
-  allShowingLabel = `All ${total} results`
-}) => (
-  <h2 className="filter-summary">
-    {
-      filtered !== total
-        ? filteredLabel
-        : allShowingLabel
-    }
-  </h2>
-);
+const FilterSummary = ({ total, filtered, filteredLabel, allShowingLabel, recordType = 'results' }) => {
+  filteredLabel = filteredLabel || `${filtered} results`;
+  allShowingLabel = allShowingLabel || `All ${total} ${recordType}`;
+
+  return (
+    <h2 className="filter-summary">
+      {
+        filtered !== total
+          ? filteredLabel
+          : allShowingLabel
+      }
+    </h2>
+  );
+};
 
 const mapStateToProps = ({
   datatable: {

--- a/src/filter-table/index.jsx
+++ b/src/filter-table/index.jsx
@@ -9,7 +9,7 @@ const FilterTable = ({
   <Fragment>
     <Filters formatters={formatters} />
     <div className="table-heading">
-      <FilterSummary />
+      <FilterSummary {...props} />
       {
         createPath && <Link label={<Snippet>addNew</Snippet>} page={createPath} />
       }


### PR DESCRIPTION
Before:
 * no search/filter: "All x results"
 * search applied: "Showing y of x results"

After:
 * no search/filter: "All x <profiles/tasks/establishments/approved areas>"
 * search applied: "y results*"