### PR TITLE
Make datatable filter summary component consistent

### DIFF
--- a/src/filter-summary/index.jsx
+++ b/src/filter-summary/index.jsx
@@ -6,13 +6,13 @@ const FilterSummary = ({ total, filtered, filteredLabel, allShowingLabel, result
   allShowingLabel = allShowingLabel || `All ${total} ${resultType}`;
 
   return (
-    <h2 className="filter-summary">
+    <h3 className="filter-summary">
       {
         filtered !== total
           ? filteredLabel
           : allShowingLabel
       }
-    </h2>
+    </h3>
   );
 };
 

--- a/src/link-filter/index.scss
+++ b/src/link-filter/index.scss
@@ -1,5 +1,5 @@
 .link-filter {
-  margin-bottom: 20px;
+  margin-bottom: 0;
 
   ul {
     display: inline-block;


### PR DESCRIPTION
In some places this had plain body styling, and in others still h2. Standardise all instances to h3.

Remove margin-bottom from link-filter component to ensure spacing between filters and heading is consistent also.