### PR TITLE
Allow custom hint content / react components for fields

### DIFF
--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -121,7 +121,7 @@ function Field({
 
   return <Component
     label={label || <Snippet>{`fields.${name}.label`}</Snippet>}
-    hint={<Snippet optional>{`fields.${name}.hint`}</Snippet>}
+    hint={hint || <Snippet optional>{`fields.${name}.hint`}</Snippet>}
     error={error && <Snippet>{`errors.${name}.${error}`}</Snippet>}
     value={fieldValue}
     onChange={onFieldChange}


### PR DESCRIPTION
There is a request to use a summary/details expander for the hint text for the primary est selector.

This brings it into line with https://github.com/UKHomeOffice/react-components/blob/master/src/forms/input.jsx#L35 which allows you to pass any valid react as the hint.

