### PR TITLE
Prevent `normaliseOptions` from mutation schema

### DIFF
--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -127,10 +127,16 @@ function Field({
     return options.map(opt => {
       if (typeof opt === 'object') {
         if (!opt.label) {
-          opt.label = getLabel(opt.value, name);
+          opt = {
+            ...opt,
+            label: getLabel(opt.value, name)
+          };
         }
         if (!opt.hint) {
-          opt.hint = getLabel(opt.value, name, 'hint');
+          opt = {
+            ...opt,
+            hint: getLabel(opt.value, name, 'hint')
+          };
         }
         return opt;
       }


### PR DESCRIPTION
Instead of setting hint and label properties directly on the option, create a copy with the properties added.

This prevents accidental mutation of the schema by passing objects as reference.