### PR TITLE
Use option label for single radio component if it is defined

### DIFF
--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -48,7 +48,7 @@ function SingleRadio(props) {
       <input type="hidden" name={props.name} value={value} />
       <h3>{ props.label }</h3>
       {
-        getLabel(value, props.fieldName)
+        settings.label || getLabel(value, props.fieldName)
       }
       {
         settings.reveal


### PR DESCRIPTION
In the context of ROPs species, the optins come with defined labels, and are not stored in content. Where a pre-defined label is provided with a SingleRadio component use that instead of looking up the content snippet.