### PR TITLE
Tweak - fix reveal flicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "dev": true
     },
     "@ukhomeoffice/react-components": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.9.1.tgz",
-      "integrity": "sha512-dCBqnjf6RdnFGE6oKPgCxEXa2yKfjnU+x5+HbdxsKfq2JQRvXUVqi9i71TS3u0THNqH8tzvZPISCBb+ar0zQkg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@ukhomeoffice/react-components/-/react-components-0.9.2.tgz",
+      "integrity": "sha512-pKE+3993gqDibExgylJ8RaQm26ISBQXpdfbd+4TOK+ND+laZE2Bg+ig+0/TdQTT7xSAi7a5WI+quA2iNTt2xug==",
       "requires": {
         "classnames": "^2.2.6",
         "react-markdown": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@asl/constants": "^0.8.3",
     "@asl/dictionary": "^1.1.5",
-    "@ukhomeoffice/react-components": "^0.9.1",
+    "@ukhomeoffice/react-components": "^0.9.2",
     "accessible-autocomplete": "^2.0.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "classnames": "^2.2.6",

--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -204,6 +204,7 @@ function Field({
     label={isUndefined(label) ? <Snippet>{`fields.${name}.label`}</Snippet> : label}
     hint={isUndefined(hint) ? <Snippet optional>{`fields.${name}.hint`}</Snippet> : hint}
     error={error && <Snippet fallback={`errors.default.${error}`}>{`errors.${name}.${error}`}</Snippet>}
+    initialHideReveals={true}
     value={fieldValue}
     onChange={onFieldChange}
     name={prefix ? `${prefix}-${name}` : name}


### PR DESCRIPTION
* Bumped react-components with option to turn off reveal pre-render
* Configured fieldset to use non-prerendered reveals. this prevents a flicker on loading a page