### PR TITLE
Bugfix - react markdown breaking changes

### DIFF
--- a/src/snippet/index.jsx
+++ b/src/snippet/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import get from 'lodash/get';
 import { connect } from 'react-redux';
 import ReactMarkdown from 'react-markdown';
@@ -19,18 +19,18 @@ export const Snippet = ({ content, children, optional, fallback, ...props }) => 
   }
   const source = trim(render(str, props));
 
-  function wrapInSpanIfOnlyChild({ children, parentChildCount }) {
-    return parentChildCount > 1
-      ? <p>{ children }</p>
-      : <span>{ children }</span>;
+  function wrapInSpanIfOnlyChild({ node, siblingCount, index, ...props }) {
+    if (siblingCount === 1) {
+      return <span {...props} />;
+    }
+    return <p {...props} />;
   }
 
   return (
     <ReactMarkdown
-      source={source}
-      includeNodeIndex={true}
-      renderers={{ root: Fragment, paragraph: wrapInSpanIfOnlyChild }}
-    />
+      includeElementIndex={true}
+      components={{ p: wrapInSpanIfOnlyChild }}
+    >{ source }</ReactMarkdown>
   );
 };
 

--- a/src/snippet/index.spec.jsx
+++ b/src/snippet/index.spec.jsx
@@ -2,6 +2,15 @@ import React from 'react';
 import { render } from 'enzyme';
 import { Snippet } from './';
 
+const string = '<span>one line</span>';
+const list = `<ul>
+<li>one</li>
+<li>two</li>
+<li>three</li>
+</ul>`;
+const paragraphs = `<p>one</p>
+<p>two</p>`;
+
 describe('<Snippet />', () => {
 
   const content = {
@@ -17,19 +26,20 @@ describe('<Snippet />', () => {
   test('does not include a wrapping element on single line input', () => {
     const wrapper = render(<div><Snippet content={content}>string</Snippet></div>);
     expect(wrapper.find('p').length).toEqual(0);
-    expect(wrapper.text()).toEqual('one line');
+    expect(wrapper.find('span').length).toEqual(1);
+    expect(wrapper.html()).toEqual(string);
   });
 
   test('includes wrapping elements on list inputs inputs', () => {
     const wrapper = render(<div><Snippet content={content}>list</Snippet></div>);
     expect(wrapper.find('ul').length).toEqual(1);
-    expect(wrapper.text()).toEqual('onetwothree');
+    expect(wrapper.html()).toEqual(list);
   });
 
   test('includes wrapping elements on multi-line paragraph inputs', () => {
     const wrapper = render(<div><Snippet content={content}>paragraphs</Snippet></div>);
     expect(wrapper.find('p').length).toEqual(2);
-    expect(wrapper.text()).toEqual('onetwo');
+    expect(wrapper.html()).toEqual(paragraphs);
   });
 
 });


### PR DESCRIPTION
* Updated snippet react markdown implementation
* Update assertions as enzyme now includes whitespace in .text()