### PR TITLE
Don't highlight changes from `null` to `''` in diffs

### DIFF
--- a/src/diff/index.jsx
+++ b/src/diff/index.jsx
@@ -33,13 +33,21 @@ function getDiff(schema, before, after) {
   }, {});
 }
 
+function hasChanged(before, after) {
+  // don't flag changes between `null` and `''`
+  if (!before && !after) {
+    return false;
+  }
+  return !(isEqual(before, after));
+}
+
 export default function Diff({
   before,
   after,
   schema,
   diff,
   formatters = {},
-  comparator = (a, b) => !(isEqual(a, b)),
+  comparator = hasChanged,
   currentLabel = 'Current',
   proposedLabel = 'Proposed'
 }) {


### PR DESCRIPTION
Where a value was previously null or undefined, and is now an empty string then don't show as a change.