### PR TITLE
Allow hints in revealed fields to be formatted, add new DetailsReveal form type

### DIFF
--- a/src/details-reveal/index.jsx
+++ b/src/details-reveal/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Fieldset } from '..';
+
+export default function DetailsReveal({ label, reveal, values, ...props }) {
+  // console.log('values', values);
+  // console.log('reveal', reveal);
+  return (
+    <details>
+      <summary>{label}</summary>
+      <Fieldset {...props} model={values} schema={reveal} />
+    </details>
+  );
+}

--- a/src/details-reveal/index.jsx
+++ b/src/details-reveal/index.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import some from 'lodash/some';
 import { Fieldset } from '..';
 
 export default function DetailsReveal({ label, reveal, values, ...props }) {
-  // console.log('values', values);
-  // console.log('reveal', reveal);
+  const open = some(reveal, (field, key) => {
+    return values[key] || (field.prefix && values[`${field.prefix}-${key}`]);
+  });
+
   return (
-    <details>
+    <details open={open}>
       <summary>{label}</summary>
       <Fieldset {...props} model={values} schema={reveal} />
     </details>

--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -102,7 +102,7 @@ function automapReveals(options, props) {
     if (opt.reveal) {
       return {
         ...opt,
-        reveal: <Inset><Fieldset schema={opt.reveal} model={props.values} errors={props.errors} /></Inset>
+        reveal: <Inset><Fieldset schema={opt.reveal} model={props.values} errors={props.errors} formatters={props.formatters} /></Inset>
       };
     }
     return opt;
@@ -177,7 +177,7 @@ function Field({
   }, [fieldValue]);
 
   if (formatHint) {
-    hint = formatHint(hint);
+    hint = formatHint({ name, prefix, hint });
   }
 
   function onFieldChange(e) {

--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -15,6 +15,7 @@ import {
 import {
   Snippet,
   ConditionalReveal,
+  DetailsReveal,
   SpeciesSelector,
   AutoComplete,
   ApplicationConfirm,
@@ -81,6 +82,7 @@ const fields = {
   select: props => <Select { ...props } />,
   selectMany: props => <SelectMany { ...props } />,
   conditionalReveal: props => <ConditionalReveal { ...props } />,
+  detailsReveal: props => <DetailsReveal { ...props } />,
   speciesSelector: props => <SpeciesSelector {...props} />,
   restrictionsField: props => <RestrictionsField {...props} />,
   inputDuration: props => <DurationField {...props} />,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -53,6 +53,7 @@ export { default as RestrictionsField } from './restrictions-field';
 export { default as Search } from './search';
 export { default as SectionList } from './section-list';
 export { default as SelectMany } from './select-many';
+export { default as DetailsReveal } from './details-reveal';
 export { default as Sidebar } from './sidebar';
 export { default as Snippet } from './snippet';
 export { default as SpeciesSelector } from './species-selector';


### PR DESCRIPTION
New input type DetailsReveal - you can add it like a field to the schema, but it does not actually capture a value itself, it just renders any reveal fields inside a details / summary.

Closed:
![closed](https://user-images.githubusercontent.com/1880478/123818287-c42d8400-d8f0-11eb-9d92-f6f9f1516bda.png)

Open:
![open](https://user-images.githubusercontent.com/1880478/123818291-c55eb100-d8f0-11eb-9d76-81af2b082bf2.png)
