### PR TITLE
Cast duration field labels to strings

### DIFF
--- a/src/duration-field/index.jsx
+++ b/src/duration-field/index.jsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import range from 'lodash/range';
 import Fieldset from '../fieldset';
 
-const generateOptions = range => range.map(value => ({ value, label: value }));
+const generateOptions = range => range.map(value => ({ value, label: value.toString() }));
 
 export default function DurationField(props) {
   const initialState = props.value || { years: '', months: '' };


### PR DESCRIPTION
Otherwise the label being `0` means that it appears falsy in the sleect component and defaults to the whole option object and renders `[Object object]`