### PR TITLE
Fix hint styling in single radios

### DIFF
--- a/src/fieldset/index.jsx
+++ b/src/fieldset/index.jsx
@@ -48,12 +48,12 @@ function SingleRadio(props) {
   return (
     <div className="govuk-form-group">
       <input type="hidden" name={props.name} value={value} />
-      <h3>{ props.label }</h3>
+      { props.label && <h3>{ props.label }</h3> }
       {
         settings.label || getLabel(value, props.fieldName)
       }
       {
-        hint && <p className="govuk-hint">{ hint }</p>
+        hint && <span className="govuk-hint">{ hint }</span>
       }
       {
         settings.reveal


### PR DESCRIPTION
The `<p>` tag used for the hint is different to the markup used for radio groups and results in excess margin. Replace with a `<span>`.

Also avoid rendering the top level label if none is defined to prevent excess whitespace from the empty `<h3>` - especially in "other" options.