### PR TITLE
Add form-group wrapper around details reveal

### DIFF
--- a/src/details-reveal/index.jsx
+++ b/src/details-reveal/index.jsx
@@ -8,9 +8,11 @@ export default function DetailsReveal({ label, reveal, values, ...props }) {
   });
 
   return (
-    <details open={open}>
-      <summary>{label}</summary>
-      <Fieldset {...props} model={values} schema={reveal} />
-    </details>
+    <div className="govuk-form-group">
+      <details open={open}>
+        <summary>{label}</summary>
+        <Fieldset {...props} model={values} schema={reveal} />
+      </details>
+    </div>
   );
 }


### PR DESCRIPTION
This ensures that the details reveal is spaced consistently with other form elements.