### PR TITLE
Truncate long titles in document header component

### DIFF
--- a/src/document-header/index.jsx
+++ b/src/document-header/index.jsx
@@ -43,7 +43,17 @@ export default function DocumentHeader({ title, subtitle, backLink, children, de
     return (
       <Fragment>
         { title && <h1>{title}</h1> }
-        { subtitle && <h2>{subtitle}</h2> }
+        <div className="title-overflow">
+          { subtitle && <h2>{subtitle}</h2> }
+          {
+            children && <a href="#" onClick={toggleDetails} className="toggle-details">
+              { detailsShowing ? `Hide ${detailsLabel}` : `View ${detailsLabel}` }
+            </a>
+          }
+        </div>
+        {
+          children && detailsShowing && <div className="details">{children}</div>
+        }
       </Fragment>
     );
   }
@@ -54,17 +64,6 @@ export default function DocumentHeader({ title, subtitle, backLink, children, de
       <header className="document-header">
         <div className="page-title">
           <Headings title={title} subtitle={subtitle} />
-          {
-            !isSticky && children &&
-              <Fragment>
-                <a href="#" onClick={toggleDetails} className="toggle-details">
-                  { detailsShowing ? `Hide ${detailsLabel}` : `View ${detailsLabel}` }
-                </a>
-                {
-                  detailsShowing && <div className="details">{children}</div>
-                }
-              </Fragment>
-          }
         </div>
 
         { !isSticky && backLink && <div className="back-link">{ backLink }</div> }

--- a/src/document-header/index.scss
+++ b/src/document-header/index.scss
@@ -40,16 +40,27 @@
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+    .title-overflow {
+      display: flex;
+      flex-direction: row;
+      
+      h2 {
+        min-width: 0; /* allows text-overflow to work inside a flexbox element */
+        font-size: 18px;
+        font-weight: normal;
+        margin-right: 1em;
+        margin-bottom: 0 !important;
 
-    h2 {
-      display: inline;
-      font-size: 18px;
-      font-weight: normal;
-      margin-right: 1em;
-    }
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
 
-    a.toggle-details {
-      font-size: 16px;
+      a.toggle-details {
+        flex: 1;
+        font-size: 16px;
+        white-space: nowrap;
+      }
     }
 
     dl {


### PR DESCRIPTION
Where a title would ordinarily flow onto multiple lines truncate the title with an ellipsis.

Before:
![Screenshot 2021-09-17 at 17 16 33](https://user-images.githubusercontent.com/117398/133821607-7a18b650-a79c-4cd8-97ea-5c4a0892abd0.png)

After:

![Screenshot 2021-09-17 at 17 16 21](https://user-images.githubusercontent.com/117398/133821595-10af1aa9-5006-47d5-bbd9-abb907442d20.png)
