### PR TITLE
Add prefix prop to override default content key

### DIFF
--- a/src/countdown/index.jsx
+++ b/src/countdown/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Snippet } from '../';
 import differenceInMonths from 'date-fns/difference_in_months';
 import differenceInWeeks from 'date-fns/difference_in_weeks';
@@ -7,7 +7,7 @@ import isBefore from 'date-fns/is_before';
 import isToday from 'date-fns/is_today';
 import classnames from 'classnames';
 
-const Countdown = ({ expiry, unit, showNotice, showUrgent, suffix }) => {
+const Countdown = ({ expiry, unit, showNotice, showUrgent, contentPrefix = 'countdown' }) => {
   const now = new Date();
 
   const diff = {
@@ -24,22 +24,19 @@ const Countdown = ({ expiry, unit, showNotice, showUrgent, suffix }) => {
   const displayDiff = Math.abs(displayUnit === 'day' ? diff[displayUnit] : diff[displayUnit] + 1);
   const urgent = diff[unit] <= showUrgent;
 
-  let contentKey = displayDiff === 1 ? 'countdown.singular' : 'countdown.plural';
+  let contentKey = displayDiff === 1 ? `${contentPrefix}.singular` : `${contentPrefix}.plural`;
 
   if (isBefore(expiry, now)) {
-    contentKey = 'countdown.expired';
+    contentKey = `${contentPrefix}.expired`;
   }
 
   if (isToday(expiry)) {
-    contentKey = 'countdown.expiresToday';
+    contentKey = `${contentPrefix}.expiresToday`;
   }
 
   return (
     <span className={classnames('notice', { urgent })}>
       <Snippet diff={displayDiff} unit={displayUnit}>{contentKey}</Snippet>
-      {
-        suffix && <Fragment>{' - '}<span>{suffix}</span></Fragment>
-      }
     </span>
   );
 };

--- a/src/countdown/index.spec.jsx
+++ b/src/countdown/index.spec.jsx
@@ -50,4 +50,19 @@ describe('<Countdown />', () => {
     expect(wrapper.find('span').length).toBe(0);
   });
 
+  describe('custom content key', () => {
+
+    test('uses in place of default key if provided', () => {
+      const expired = shallow(<Countdown expiry={'2017-01-01'} contentPrefix="custom" />);
+      expect(expired.find(Snippet).props().children).toEqual('custom.expired');
+
+      const today = shallow(<Countdown expiry={new Date()} contentPrefix="custom" />);
+      expect(today.find(Snippet).props().children).toEqual('custom.expiresToday');
+
+      const tomorrow = shallow(<Countdown expiry={endOfTomorrow()} contentPrefix="custom" />);
+      expect(tomorrow.find(Snippet).props().children).toEqual('custom.singular');
+    });
+
+  });
+
 });


### PR DESCRIPTION
This allows multiple contdown elements to be used in the same page with different content. In particular on task lists there is a need to have a continuation countdown and a deadline countdown.