### PR TITLE
Change threshold for switching from weeks to days in Countdown

### DIFF
--- a/src/countdown/index.jsx
+++ b/src/countdown/index.jsx
@@ -20,7 +20,7 @@ const Countdown = ({ expiry, unit, showNotice, showUrgent, contentPrefix = 'coun
     return null;
   }
 
-  const displayUnit = diff['day'] <= 7 ? 'day' : (diff['week'] <= 13 ? 'week' : 'month');
+  const displayUnit = diff['day'] <= 14 ? 'day' : (diff['week'] <= 13 ? 'week' : 'month');
   const displayDiff = Math.abs(displayUnit === 'day' ? diff[displayUnit] : diff[displayUnit] + 1);
   const urgent = diff[unit] <= showUrgent;
 

--- a/src/countdown/index.spec.jsx
+++ b/src/countdown/index.spec.jsx
@@ -31,8 +31,8 @@ describe('<Countdown />', () => {
     expect(wrapper.find(Snippet).props().diff).toEqual(1);
   });
 
-  test('shows less than x weeks left if the expiry date is greater than 1 week but less than a month', () => {
-    const wrapper = shallow(<Countdown expiry={addWeeks(new Date(), 2)} />);
+  test('shows less than x weeks left if the expiry date is greater than 2 weeks but less than a month', () => {
+    const wrapper = shallow(<Countdown expiry={addWeeks(new Date(), 3)} />);
     expect(wrapper.find(Snippet).length).toBe(1);
     expect(wrapper.find(Snippet).props().unit).toEqual('week');
     expect(wrapper.find(Snippet).props().children).toEqual('countdown.plural');


### PR DESCRIPTION
Show value in days for the last two weeks instead of one week.