### PR TITLE
Move h2 styles out of `.title-overflow` context

### DIFF
--- a/src/document-header/index.scss
+++ b/src/document-header/index.scss
@@ -40,14 +40,16 @@
       white-space: nowrap;
       text-overflow: ellipsis;
     }
+    h2 {
+      font-size: 18px;
+      font-weight: normal;
+    }
     .title-overflow {
       display: flex;
       flex-direction: row;
-      
+
       h2 {
         min-width: 0; /* allows text-overflow to work inside a flexbox element */
-        font-size: 18px;
-        font-weight: normal;
         margin-right: 1em;
         margin-bottom: 0 !important;
 


### PR DESCRIPTION
These styles need to apply once a user has scrolled down and the sticky header format is used. This doesn't include the `.title-overflow` container, so the styles were being wrongly removed.