### PR TITLE
Use content labels for training modules

### DIFF
--- a/src/training-summary/index.jsx
+++ b/src/training-summary/index.jsx
@@ -39,7 +39,7 @@ function Row({ certificate, actions, basePage }) {
   return (
     <tr>
       <td>{certificate.isExemption ? 'Exemption' : 'Training certificate'}</td>
-      <td><List items={certificate.modules} /></td>
+      <td><List items={certificate.modules.map(module => <Snippet key={module}>{ `trainingModules.${module}` }</Snippet>)} /></td>
       <td><List items={certificate.species} /></td>
       <td>
         {


### PR DESCRIPTION
The new training module has a long and descriptive name which seems likely to change in future without wanting to touch the underlying data, so switch to mapping training module codes to content strings to make that easy.