### PR TITLE
Don't removed preset species from species selector value

### DIFF
--- a/src/species-selector/index.jsx
+++ b/src/species-selector/index.jsx
@@ -6,7 +6,6 @@ import values from 'lodash/values';
 import flatten from 'lodash/flatten';
 import omit from 'lodash/omit';
 import intersection from 'lodash/intersection';
-import without from 'lodash/without';
 import pick from 'lodash/pick';
 import { InputWrapper } from '@ukhomeoffice/react-components';
 import { MultiInput, Fieldset } from '../';
@@ -91,11 +90,10 @@ export default function SpeciesSelector(props) {
     const nopes = props.projectSpecies
       ? (species[name] || []).map(o => o.value)
       : (species[name].types || []);
-    const v = uniq(value.precoded.filter(item => !nopes.includes(item)).concat(val[`_${props.name}`]));
+    const precoded = uniq(value.precoded.filter(item => !nopes.includes(item)).concat(val[`_${props.name}`]));
     setValue({
       ...value,
-      // eslint-disable-next-line no-useless-call
-      precoded: without.apply(null, [ v, ...presets ])
+      precoded
     });
   };
 


### PR DESCRIPTION
In ROPs there are two reasons a species might be preset - if it is included on the project already, or if it has been used in a procedure. The removal of preset species was intended to avoid duplicating the former case, but resulted in species used in procedures being completely removed from the saved values.

If it is disabled because it has been used in a procedure then it needs to be persisted on the species selector value and not removed.