### PR TITLE
Add a bottom margin to the checkbox groups inside the species selector

### DIFF
--- a/src/species-selector/index.scss
+++ b/src/species-selector/index.scss
@@ -3,4 +3,7 @@
     color: $blue;
     cursor: pointer;
   }
+  details > fieldset {
+    margin-bottom: $govuk-gutter-half !important;
+  }
 }


### PR DESCRIPTION
This adds some space between the last checkbox and the following category heading.

I'm not delighted by the `!important` but it's overriding some generic `.govuk-inset-text` styling that feels like a risk to unpick, and this is fairly specific to this component.

Before:
<img width="537" alt="Screenshot 2021-11-10 at 10 12 17" src="https://user-images.githubusercontent.com/117398/141094593-89e94c50-91ce-47c7-af92-69a09d2e8799.png">

After:
<img width="479" alt="Screenshot 2021-11-10 at 10 12 35" src="https://user-images.githubusercontent.com/117398/141094619-193d6d48-6287-4c01-938d-68ce90e7d7cd.png">
