### PR TITLE
Allow links to specify if they should open in separate tab

### DIFF
--- a/src/link/index.jsx
+++ b/src/link/index.jsx
@@ -35,13 +35,17 @@ export function getUrl({ page, url, query, path, suffix, ...props }) {
   return query ? `${href}?${stringify(query)}` : href;
 }
 
-export default function Link({ label, className, ...props }) {
+export default function Link({ label, className, newTab = false, ...props }) {
   const isPdf = useSelector(state => state.static.isPdf);
   if (isPdf) {
     return null;
   }
 
   const href = getUrl({ ...props });
+
+  if (newTab) {
+    return <a className={className} href={href} target="_blank" rel="noreferrer">{label}</a>;
+  }
 
   return <a className={className} href={href}>{label}</a>;
 }

--- a/src/link/index.jsx
+++ b/src/link/index.jsx
@@ -35,7 +35,7 @@ export function getUrl({ page, url, query, path, suffix, ...props }) {
   return query ? `${href}?${stringify(query)}` : href;
 }
 
-export default function Link({ label, className, newTab = false, ...props }) {
+export default function Link({ label, className, target, ...props }) {
   const isPdf = useSelector(state => state.static.isPdf);
   if (isPdf) {
     return null;
@@ -43,9 +43,5 @@ export default function Link({ label, className, newTab = false, ...props }) {
 
   const href = getUrl({ ...props });
 
-  if (newTab) {
-    return <a className={className} href={href} target="_blank" rel="noreferrer">{label}</a>;
-  }
-
-  return <a className={className} href={href}>{label}</a>;
+  return <a className={className} href={href} target={target}>{label}</a>;
 }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -54,3 +54,7 @@ $highlight-colour: govuk-colour('grey-4');
 .float-left {
   float: left;
 }
+
+.align-right {
+  text-align: right;
+}


### PR DESCRIPTION
Also added a new class for right-aligning text, otherwise multi-line `float-right` elements look a bit weird.

<img width="275" alt="dd-no-right-align" src="https://user-images.githubusercontent.com/1880478/141468055-e670230c-3ab8-4377-ad7f-861f91499f63.png">

<img width="343" alt="dd-right" src="https://user-images.githubusercontent.com/1880478/141467789-746cfe1f-b62b-4ff8-b0a7-38a5d9ad56eb.png">
