### PR TITLE
Custom datatable rows

### DIFF
--- a/src/datatable/index.jsx
+++ b/src/datatable/index.jsx
@@ -57,6 +57,7 @@ export function Row({ row, schema, Expandable, Actions, expands, alwaysExpanded 
 }
 
 export function Datatable({
+  CustomRow,
   expands = () => true,
   Expandable,
   alwaysExpanded = false,
@@ -90,9 +91,14 @@ export function Datatable({
       </thead>
       <tbody>
         {
-          data.length === 0 && noDataWarning
-            ? <tr><td colSpan={size(schema) + (Actions ? 1 : 0)}>{noDataWarning}</td></tr>
-            : data.map(row => <Row key={row.id} schema={schema} row={row} Expandable={Expandable} Actions={Actions} expands={expands} alwaysExpanded={alwaysExpanded} />)
+          data.length === 0 && noDataWarning && <tr><td colSpan={size(schema) + (Actions ? 1 : 0)}>{noDataWarning}</td></tr>
+        }
+        {
+          data.length && data.map(row =>
+            CustomRow
+              ? <CustomRow key={row.id} schema={schema} row={row} Expandable={Expandable} Actions={Actions} expands={expands} alwaysExpanded={alwaysExpanded} />
+              : <Row key={row.id} schema={schema} row={row} Expandable={Expandable} Actions={Actions} expands={expands} alwaysExpanded={alwaysExpanded} />
+          )
         }
       </tbody>
       {

--- a/src/datatable/index.jsx
+++ b/src/datatable/index.jsx
@@ -73,6 +73,8 @@ export function Datatable({
   noDataWarning
 }) {
   const schema = pickBy(merge({}, tableSchema, formatters), (item, key) => item.show);
+  const RowComponent = CustomRow || Row;
+  const colSpan = size(schema) + (Actions ? 1 : 0);
 
   return (
     <table className={classnames('govuk-table', 'govuk-react-datatable', className, isFetching && 'loading')}>
@@ -91,13 +93,11 @@ export function Datatable({
       </thead>
       <tbody>
         {
-          data.length === 0 && noDataWarning && <tr><td colSpan={size(schema) + (Actions ? 1 : 0)}>{noDataWarning}</td></tr>
+          data.length === 0 && noDataWarning && <tr><td colSpan={colSpan}>{noDataWarning}</td></tr>
         }
         {
-          data.length && data.map(row =>
-            CustomRow
-              ? <CustomRow key={row.id} schema={schema} row={row} Expandable={Expandable} Actions={Actions} expands={expands} alwaysExpanded={alwaysExpanded} />
-              : <Row key={row.id} schema={schema} row={row} Expandable={Expandable} Actions={Actions} expands={expands} alwaysExpanded={alwaysExpanded} />
+          data.map(row =>
+            <RowComponent key={row.id} schema={schema} row={row} Expandable={Expandable} Actions={Actions} expands={expands} alwaysExpanded={alwaysExpanded} />
           )
         }
       </tbody>
@@ -105,7 +105,7 @@ export function Datatable({
         !pagination.hideUI &&
           <tfoot>
             <tr>
-              <td colSpan={size(schema) + (Actions ? 1 : 0)}>
+              <td colSpan={colSpan}>
                 <Pagination />
               </td>
             </tr>

--- a/src/form/index.jsx
+++ b/src/form/index.jsx
@@ -13,12 +13,12 @@ const extendSchema = (field, formatter) => {
   };
 };
 
-const mapStateToProps = ({ static: { schema, errors, csrfToken, values }, model }, { formatters = {}, model: ownModel, schema: ownSchema }) => {
+const mapStateToProps = ({ static: { schema, errors, csrfToken, values }, model }, { formatters = {}, model: ownModel, schema: ownSchema, errors: ownErrors }) => {
   schema = ownSchema || schema;
   return {
     model: ownModel || model,
     values,
-    errors,
+    errors: ownErrors || errors,
     csrfToken,
     schema: mapValues(schema, (field, key) => extendSchema(field, formatters[key]))
   };


### PR DESCRIPTION
Allow the parent of `<Datatable />` to pass in a custom component to be used for the entire row.