### PR TITLE
Pass linkTarget prop to markdown for new tabs

### DIFF
--- a/src/snippet/index.jsx
+++ b/src/snippet/index.jsx
@@ -20,6 +20,7 @@ export const Snippet = ({ content, children, optional, fallback, ...props }) => 
   return (
     <Markdown
       unwrapSingleLine={true}
+      linkTarget={props.linkTarget}
     >{ source }</Markdown>
   );
 };


### PR DESCRIPTION
`<Snippet linkTarget="_blank">` will then open markdown links in a new tab