### PR TITLE
Allow insertion of custom status component in document header

### DIFF
--- a/src/document-header/index.jsx
+++ b/src/document-header/index.jsx
@@ -2,7 +2,7 @@ import React, { Fragment, useState, useRef, useEffect } from 'react';
 import classnames from 'classnames';
 import { BackToTop } from '../';
 
-export default function DocumentHeader({ title, subtitle, backLink, children, detailsLabel = 'downloads' }) {
+export default function DocumentHeader({ title, subtitle, backLink, children, detailsLabel = 'downloads', status = null }) {
   const [detailsShowing, updateDetailsShowing] = useState(false);
 
   const toggleDetails = (e) => {
@@ -30,19 +30,22 @@ export default function DocumentHeader({ title, subtitle, backLink, children, de
   function Headings({ title, subtitle }) {
     if (isSticky) {
       return (
-        <h2>
-          {
-            title
-              ? <Fragment>{title}: {subtitle}</Fragment>
-              : subtitle
-          }
-        </h2>
+        <Fragment>
+          <h2>
+            {
+              title
+                ? <Fragment>{title}: {subtitle}</Fragment>
+                : subtitle
+            }
+            {status}
+          </h2>
+        </Fragment>
       );
     }
 
     return (
       <Fragment>
-        { title && <h1>{title}</h1> }
+        { title && <h1>{title} {status}</h1> }
         <div className="title-overflow">
           { subtitle && <h2>{subtitle}</h2> }
           {


### PR DESCRIPTION
This supports the injection of a saved/syncing indicator into the document header for PPL applications.

It is a no-op for non-PPL licences.