### PR TITLE
Forgot to pass error / hint / fieldName

### DIFF
--- a/src/species-selector/index.jsx
+++ b/src/species-selector/index.jsx
@@ -135,7 +135,7 @@ export default function SpeciesSelector(props) {
 
   return (
     <div className="species-selector">
-      <InputWrapper {...pick(props, ['id', 'name', 'label', 'disabled'])}>
+      <InputWrapper {...pick(props, ['id', 'name', 'fieldName', 'label', 'hint', 'error', 'onChange', 'disabled'])}>
         {
           map(omit(species, 'OTHER'), (group, key) => {
             const options = group.types || group;


### PR DESCRIPTION
The change that introduced this was swapping:

```
<InputWrapper {...props }>
```
for 
```
<InputWrapper {...pick(props, ['id', 'name', 'label', 'disabled'])}>
```

Maybe this is better as an `omit()` rather than a `pick()`?

This is the error it's fixing:
![Screenshot 2022-11-11 at 12 42 09](https://user-images.githubusercontent.com/1880478/201342725-e369c163-fa25-41c1-98e1-54e6416af450.png)
