### PR TITLE
[ASL-4474] Model Summary - Recursively show revealled properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/asl-components",
-  "version": "13.1.0",
+  "version": "13.2.0",
   "description": "React components for ASL layouts and elements",
   "main": "src/index.jsx",
   "styles": "styles/index.scss",


### PR DESCRIPTION
For fields that have radios that conditionally reveal another field when selected - the model summary should have an option show that nested field. E.g. When showing a model with a conditional reveal like this:

![Screenshot 2024-02-20 at 18 21 47](https://github.com/UKHomeOffice/asl-components/assets/87995501/bacf6f1f-70fc-4573-af64-6edf3c94487a)

The model summary should display the nested purchase order field like this:

![Screenshot 2024-02-20 at 18 18 44](https://github.com/UKHomeOffice/asl-components/assets/87995501/7b48dcae-76cd-40af-832d-9e461259c356)
