### PR TITLE
[ASL-4595] Use govuk list styles for markdown lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukhomeoffice/asl-components",
-  "version": "13.7.0",
+  "version": "13.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukhomeoffice/asl-components",
-      "version": "13.7.0",
+      "version": "13.8.0",
       "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/asl-components",
-  "version": "13.7.0",
+  "version": "13.8.0",
   "description": "React components for ASL layouts and elements",
   "main": "src/index.jsx",
   "styles": "styles/index.scss",

--- a/src/markdown/index.jsx
+++ b/src/markdown/index.jsx
@@ -9,10 +9,14 @@ function RenderLink({ href, children }) {
 function RenderLinkReference({ children }) {
     return <Fragment>[{ children }]</Fragment>;
 }
+function RenderUnorderedList({ children }) {
+    return <ul className='govuk-list govuk-list--bullet'>{children}</ul>;
+}
 
 const components = {
     link: RenderLink,
-    linkReference: RenderLinkReference
+    linkReference: RenderLinkReference,
+    ul: RenderUnorderedList,
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/src/markdown/index.jsx
+++ b/src/markdown/index.jsx
@@ -10,7 +10,7 @@ function RenderLinkReference({ children }) {
     return <Fragment>[{ children }]</Fragment>;
 }
 function RenderUnorderedList({ children }) {
-    return <ul className='govuk-list govuk-list--bullet'>{children}</ul>;
+    return <ul className='govuk-list govuk-list--bullet'>{ children }</ul>;
 }
 
 const components = {

--- a/src/snippet/index.spec.jsx
+++ b/src/snippet/index.spec.jsx
@@ -3,7 +3,7 @@ import { render } from 'enzyme';
 import { Snippet } from './';
 
 const string = '<span>one line</span>';
-const list = `<ul>
+const list = `<ul class="govuk-list govuk-list--bullet">
 <li>one</li>
 <li>two</li>
 <li>three</li>


### PR DESCRIPTION
https://design-system.service.gov.uk/styles/lists/ these styles should be used when rendering unordered lists in markdown.

https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4595 needs this to get the correct list styling for the before you nominate page.
