### PR TITLE
[ASL-4703] Fix squashed status-bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukhomeoffice/asl-components",
-  "version": "13.9.0",
+  "version": "13.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukhomeoffice/asl-components",
-      "version": "13.9.0",
+      "version": "13.9.1",
       "license": "MIT",
       "dependencies": {
         "@ukhomeoffice/asl-constants": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/asl-components",
-  "version": "13.9.0",
+  "version": "13.9.1",
   "description": "React components for ASL layouts and elements",
   "main": "src/index.jsx",
   "styles": "styles/index.scss",

--- a/src/status-bar/index.scss
+++ b/src/status-bar/index.scss
@@ -1,4 +1,4 @@
-.wrapper-header .content {
+.wrapper-header {
   @include govuk-grid-row;
 
   > nav {
@@ -27,3 +27,4 @@
     }
   }
 }
+


### PR DESCRIPTION
`@include govuk-grid-column(one-third);` uses % based width in newer govuk design system, so needs to be at the top level of the header, not nested in a content div.

See also https://github.com/UKHomeOffice/asl-service/pull/271